### PR TITLE
[DM-19540] Add logging infrastructure

### DIFF
--- a/logging/Dockerfile.kibana_no_security
+++ b/logging/Dockerfile.kibana_no_security
@@ -1,0 +1,2 @@
+FROM amazon/opendistro-for-elasticsearch-kibana:0.8.0
+RUN /usr/share/kibana/bin/kibana-plugin remove opendistro_security

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,0 +1,16 @@
+# Logging
+
+This folder sets up the services required to spin up a log aggregator.
+
+The helm charts used here are:
+
+1. Elasticsearch - the indexer where the logs are stored
+and queried from.  Elasticsearch needs persistent storage available,
+but doesn't need to run on every node.
+
+2. Fluentd - a daemonset, on every node (even dedicated
+nodes).  This pod mounts the root filesystem and slurps up the logs
+in various places marked in the config.  These logs are forwarded
+to Elasticsearch.
+
+3. Kibana - the frontend for searching and viewing search results.

--- a/logging/create.sh
+++ b/logging/create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+helm install stable/elasticsearch --name nordic-bunny --namespace logging --values es-values.yaml
+helm install kiwigrid/fluentd-elasticsearch --name no-turkey --values fluentd-es-values.yaml --namespace logging
+helm install stable/kibana --name ardent-ladybug --values kibana-values.yaml --namespace logging
+kubectl create -f ingress.yaml --namespace logging

--- a/logging/destroy.sh
+++ b/logging/destroy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+
+helm delete --purge ardent-ladybug
+helm delete --purge nordic-bunny
+helm delete --purge no-turkey

--- a/logging/destroy.sh
+++ b/logging/destroy.sh
@@ -4,3 +4,5 @@ set -x
 helm delete --purge ardent-ladybug
 helm delete --purge nordic-bunny
 helm delete --purge no-turkey
+
+kubectl delete ingress -n logging kibana-ingress

--- a/logging/es-values.yaml
+++ b/logging/es-values.yaml
@@ -1,0 +1,34 @@
+image:
+  repository: "amazon/opendistro-for-elasticsearch"
+  tag: "0.8.0"
+master:
+  persistence:
+    enabled: false
+data:
+  replicas: 3
+  persistence:
+    enabled: false
+    #name: 'pvc-lspelk'
+    #size: '100Gi'
+  heapSize: "2g"
+  resources:
+    limits:
+      cpu: "2"
+      memory: "4096Mi"
+    requests:
+      cpu: "2"
+      memory: "4096Mi"
+client:
+  replicas: 12
+  heapSize: "2g"
+  resources:
+    limits:
+      cpu: "2"
+      memory: "4096Mi"
+    requests:
+      cpu: "2"
+      memory: "4096Mi"
+cluster:
+  config:
+    opendistro_security.disabled: true
+

--- a/logging/es-values.yaml
+++ b/logging/es-values.yaml
@@ -5,29 +5,29 @@ master:
   persistence:
     enabled: false
 data:
-  replicas: 3
+  replicas: 6
   persistence:
     enabled: false
     #name: 'pvc-lspelk'
     #size: '100Gi'
-  heapSize: "2g"
+  heapSize: "1g"
   resources:
     limits:
       cpu: "2"
-      memory: "4096Mi"
+      memory: 8G
     requests:
       cpu: "2"
-      memory: "4096Mi"
+      memory: 7G
 client:
   replicas: 12
   heapSize: "2g"
   resources:
     limits:
       cpu: "2"
-      memory: "4096Mi"
+      memory: 8G
     requests:
       cpu: "2"
-      memory: "4096Mi"
+      memory: 7G
 cluster:
   config:
     opendistro_security.disabled: true

--- a/logging/fluentd-es-values.yaml
+++ b/logging/fluentd-es-values.yaml
@@ -1,0 +1,48 @@
+elasticsearch:
+  host: nordic-bunny-elasticsearch-client
+  buffer_chunk_limit: 100M
+  buffer_queue_limit: 32
+tolerations:
+ - key: "dedicated"
+   operator: "Exists"
+   effect: "NoSchedule"
+extraVolumes:
+  - name: qservlogs
+    hostPath:
+      path: /qserv/log
+extraVolumeMounts:
+  - name: qservlogs
+    mountPath: /qserv/log
+configMaps:
+  qserv.conf: |-
+    # Example line:
+    # 2019-04-24 23:05:29 140240301914240 [Note] InnoDB: 5.7.21 started; log sequence number 28871386
+    <source>
+      @id mysqld
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\d{4}-\d{2}-\d{2}/
+      format1 /(?<time>[^ ]* [^ ]*) (?<thread_id>[^ ]*) \[(?<level>[^ ]*)\] (?<message>[^ ].*$)/
+      time_format %Y-%m-%d %H:%M:%S
+      path /qserv/log/mysqld.log
+      #pos_file /qserv/log/mysqld.log.pos
+      tag mysqld
+      read_from_head true
+    </source>
+
+    # Example line:
+    # [2019-04-25T19:12:21.484Z] [LWP:323] INFO  xrdssi.msgs (xrootd:0) - qserv.11:21@141.142.181.128 Ssi_ProcessResponse: 0:/worker/db01 [bound doRsp] Resp strm
+    <source>
+      @id xrootd
+      @type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\[\d{4}-\d{2}-\d{2}T/
+      format1 /\[(?<time>[^ ]*T[^ ]*)\] (?<thread_id>[^ ]*) (?<level>[^ ]*)\s*(?<message>[^ ].*$)/
+      time_format %Y-%m-%dT%H:%M:%S
+      path /qserv/log/xrootd.log
+      #pos_file /qserv/log/xrootd.log.pos
+      tag xrootd
+      read_from_head true
+    </source>

--- a/logging/fluentd-es-values.yaml
+++ b/logging/fluentd-es-values.yaml
@@ -18,14 +18,25 @@ configMaps:
     <source>
       @id mysqld
       @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\d{4}-\d{2}-\d{2}/
-      format1 /(?<time>[^ ]* [^ ]*) (?<thread_id>[^ ]*) \[(?<level>[^ ]*)\] (?<message>[^ ].*$)/
-      time_format %Y-%m-%d %H:%M:%S
+      format /(?<time>\S*\s+\S*) (?<thread_id>\S+) \[(?<level>\S*)\]\s+(?<message>.*)/
+      time_format %Y-%m-%d %k:%M:%S
       path /qserv/log/mysqld.log
       pos_file /qserv/log/mysqld.log.pos
       tag "mysqld.#{ENV['K8S_NODE_NAME']}"
+      read_from_head true
+      emit_unmatched_lines true
+    </source>
+
+    # Example line:
+    # 2019-04-24 22:22:42: (message) Initiating shutdown, requested from signal handler
+    <source>
+      @id mysql-proxy
+      @type tail
+      format /(?<time>\S+\s+\S+) \((?<level>\S*)\)\s+(?<message>.*)/
+      time_format %Y-%m-%d %H:%M:%S
+      path /qserv/log/mysql-proxy.log
+      pos_file /qserv/log/mysql-proxy.log.pos
+      tag "mysql-proxy.#{ENV['K8S_NODE_NAME']}"
       read_from_head true
       emit_unmatched_lines true
     </source>
@@ -35,14 +46,25 @@ configMaps:
     <source>
       @id xrootd
       @type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\[\d{4}-\d{2}-\d{2}T/
-      format1 /\[(?<time>[^ ]*T[^ ]*)\] (?<thread_id>[^ ]*) (?<level>[^ ]*)\s*(?<message>[^ ].*$)/
-      time_format %Y-%m-%dT%H:%M:%S
+      format /^\[(?<time>\S+T\S+)\] (?<thread_id>\S+) (?<level>\S+)\s+(?<message>.*)/
+      time_format %Y-%m-%dT%H:%M:%S.%L
       path /qserv/log/xrootd.log
       pos_file /qserv/log/xrootd.log.pos
       tag "xrootd.#{ENV['K8S_NODE_NAME']}"
+      read_from_head true
+      emit_unmatched_lines true
+    </source>
+
+    # Example line:
+    # [2019-04-30T22:31:33.975Z] [LWP:393] INFO  mysql-proxy (qserv/mysqlProxy.lua:480) - Intercepted: SELECT 1
+    <source>
+      @id mysql-proxy-lua
+      @type tail
+      format /\[(?<time>\S+T\S+)\] (?<thread_id>\S+) (?<level>\S+)\s+(?<message>.*)/
+      time_format %Y-%m-%dT%H:%M:%S.%L
+      path /qserv/log/mysql-proxy-lua.log
+      pos_file /qserv/log/mysql-proxy-lua.log.pos
+      tag "mysql-proxy-lua.#{ENV['K8S_NODE_NAME']}"
       read_from_head true
       emit_unmatched_lines true
     </source>

--- a/logging/fluentd-es-values.yaml
+++ b/logging/fluentd-es-values.yaml
@@ -1,7 +1,5 @@
 elasticsearch:
   host: nordic-bunny-elasticsearch-client
-  buffer_chunk_limit: 100M
-  buffer_queue_limit: 32
 tolerations:
  - key: "dedicated"
    operator: "Exists"
@@ -26,9 +24,10 @@ configMaps:
       format1 /(?<time>[^ ]* [^ ]*) (?<thread_id>[^ ]*) \[(?<level>[^ ]*)\] (?<message>[^ ].*$)/
       time_format %Y-%m-%d %H:%M:%S
       path /qserv/log/mysqld.log
-      #pos_file /qserv/log/mysqld.log.pos
-      tag mysqld
+      pos_file /qserv/log/mysqld.log.pos
+      tag "mysqld.#{ENV['K8S_NODE_NAME']}"
       read_from_head true
+      emit_unmatched_lines true
     </source>
 
     # Example line:
@@ -42,7 +41,8 @@ configMaps:
       format1 /\[(?<time>[^ ]*T[^ ]*)\] (?<thread_id>[^ ]*) (?<level>[^ ]*)\s*(?<message>[^ ].*$)/
       time_format %Y-%m-%dT%H:%M:%S
       path /qserv/log/xrootd.log
-      #pos_file /qserv/log/xrootd.log.pos
-      tag xrootd
+      pos_file /qserv/log/xrootd.log.pos
+      tag "xrootd.#{ENV['K8S_NODE_NAME']}"
       read_from_head true
+      emit_unmatched_lines true
     </source>

--- a/logging/ingress.yaml
+++ b/logging/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+  name: kibana-ingress
+spec:
+  rules:
+  - host: lsst-lsp-stable.ncsa.illinois.edu
+    http:
+      paths:
+      - path: /logs
+        backend:
+          serviceName: ardent-ladybug-kibana
+          servicePort: 5601

--- a/logging/ingress.yaml
+++ b/logging/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-    nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:portal
+    nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:ops
     nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-int.ncsa.illinois.edu/oauth2/sign_in
     nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/logging/ingress.yaml
+++ b/logging/ingress.yaml
@@ -7,10 +7,15 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+    nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:portal
+    nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-int.ncsa.illinois.edu/oauth2/sign_in
+    nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
   name: kibana-ingress
 spec:
   rules:
-  - host: lsst-lsp-stable.ncsa.illinois.edu
+  - host: lsst-lsp-int.ncsa.illinois.edu
     http:
       paths:
       - path: /logs

--- a/logging/kibana-values.yaml
+++ b/logging/kibana-values.yaml
@@ -1,0 +1,10 @@
+image:
+  repository: "lsstdax/kibana-no-security"
+  #repository: "amazon/opendistro-for-elasticsearch-kibana"
+  tag: "0.8.0"
+
+files:
+  kibana.yml:
+    elasticsearch.url: http://nordic-bunny-elasticsearch-client:9200
+    server.basePath: /logs
+    server.rewriteBasePath: true


### PR DESCRIPTION
This allows for a kubernetes cluster to run fluentd to collect and manage logs from the hosts and the kubernetes pods running on them.  This is then sent to an elasticsearch index and is available to kibana for front end searching by admins.  The kibana endpoint is protected with the auth proxy, although the kibana auth is currently disabled.