### PR TITLE
[DM-19540] Adjust fluentd GC

### DIFF
--- a/logging/fluentd-es-values.yaml
+++ b/logging/fluentd-es-values.yaml
@@ -1,5 +1,7 @@
 elasticsearch:
   host: nordic-bunny-elasticsearch-client
+env:
+ RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: 0.9
 tolerations:
  - key: "dedicated"
    operator: "Exists"


### PR DESCRIPTION
This was because we noticed high memory usage, probably because
of logs being ingested but then the GC never really gives up
enough memory.