### PR TITLE
[DM-22090] landing-page helm values for int

### DIFF
--- a/lsst-lsp-int/landing-page.yaml
+++ b/lsst-lsp-int/landing-page.yaml
@@ -1,0 +1,4 @@
+motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+host: "lsst-lsp-int.ncsa.illinois.edu"
+image:
+  tag: "3.0"


### PR DESCRIPTION
Add in a new directory for lsst-lsp-int, with the values used for
the landing-page to deploy it on int.