### PR TITLE
[DM-22180] Prototype argo-cd control for -int

### DIFF
--- a/argo-cd/argo-cd-values.yaml
+++ b/argo-cd/argo-cd-values.yaml
@@ -1,0 +1,30 @@
+#global:
+#  image:
+    #repository: lsstdax/argocd
+    #tag: 'exp-0.0.1'
+    #tag: 'exp-0.0.2' - broken
+    #tag: 'exp-no-change'
+    #imagePullPolicy: Always
+
+redis:
+  enabled: true
+
+server:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    paths:
+    - /argo-cd(/|$)(.*)
+
+  extraArgs:
+    basehref: /argo-cd
+    insecure: true
+
+  config:
+    helm.repositories: |
+      - url: https://lsst-sqre.github.io/charts/
+        name: lsst-sqre
+      - url: https://ricoberger.github.io/helm-charts/
+        name: ricoberger

--- a/argo-cd/create.sh
+++ b/argo-cd/create.sh
@@ -1,0 +1,1 @@
+helm install argo/argo-cd --namespace argocd --values argo-cd-values.yaml --name argocd

--- a/argo-cd/destroy.sh
+++ b/argo-cd/destroy.sh
@@ -1,0 +1,2 @@
+helm delete --purge argocd
+kubectl delete crd -l app.kubernetes.io/part-of=argocd

--- a/argo-cd/lsst-lsp-int-values.yaml
+++ b/argo-cd/lsst-lsp-int-values.yaml
@@ -1,0 +1,29 @@
+redis:
+  enabled: true
+
+server:
+  ingress:
+    enabled: true
+    hosts:
+      - lsst-lsp-int.ncsa.illinois.edu
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:admin
+      nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-int.ncsa.illinois.edu/oauth2/sign_in
+      nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+       error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
+    paths:
+    - /argo-cd(/|$)(.*)
+
+  extraArgs:
+    basehref: /argo-cd
+    insecure: true
+
+  config:
+    helm.repositories: |
+      - url: https://lsst-sqre.github.io/charts/
+        name: lsst-sqre
+      - url: https://ricoberger.github.io/helm-charts/
+        name: ricoberger

--- a/lsst-lsp-int/cadc-tap.yaml
+++ b/lsst-lsp-int/cadc-tap.yaml
@@ -3,6 +3,13 @@ use_mock_qserv: False
 
 host: "lsst-lsp-int.ncsa.illinois.edu"
 
+secrets:
+  enabled: False
+
+vault_secrets:
+  enabled: True
+  path: 'secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/tap'
+
 ingress:
   authenticated_annotations:
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/science-platform-int/Chart.yaml
+++ b/science-platform-int/Chart.yaml
@@ -1,0 +1,1 @@
+name: science-platform-int

--- a/science-platform-int/templates/landing-page-application.yaml
+++ b/science-platform-int/templates/landing-page-application.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: landing-page
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: landing-page
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: landing-page
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: landing-page
+    repoURL: https://github.com/lsst-sqre/charts.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/tickets/DM-22180/lsst-lsp-int/landing-page.yaml
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform-int/templates/tap-application.yaml
+++ b/science-platform-int/templates/tap-application.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tap
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tap
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: lsst-lsp-int-dax
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: cadc-tap
+    repoURL: https://github.com/lsst-sqre/charts.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/tickets/DM-22180/lsst-lsp-int/cadc-tap.yaml
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform-int/templates/tap-application.yaml
+++ b/science-platform-int/templates/tap-application.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: tap
+  name: lsst-lsp-int-dax-tap
 spec:
   finalizers:
     - kubernetes
@@ -15,7 +15,7 @@ metadata:
   - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: lsst-lsp-int-dax
+    namespace: lsst-lsp-int-dax-tap
     server: https://kubernetes.default.svc
   project: default
   source:

--- a/science-platform/Chart.yaml
+++ b/science-platform/Chart.yaml
@@ -1,0 +1,1 @@
+name: science-platform

--- a/science-platform/requirements.yaml
+++ b/science-platform/requirements.yaml
@@ -1,0 +1,7 @@
+dependencies:
+  - name: landing-page
+    version: ">=0.1.0"
+    repository: https://lsst-sqre.github.io/charts/
+  - name: cadc-tap
+    version: ">=0.1.0"
+    repository: https://lsst-sqre.github.io/charts/

--- a/science-platform/requirements.yaml
+++ b/science-platform/requirements.yaml
@@ -1,7 +1,0 @@
-dependencies:
-  - name: landing-page
-    version: ">=0.1.0"
-    repository: https://lsst-sqre.github.io/charts/
-  - name: cadc-tap
-    version: ">=0.1.0"
-    repository: https://lsst-sqre.github.io/charts/

--- a/science-platform/templates/firefly-application.yaml
+++ b/science-platform/templates/firefly-application.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: firefly
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: firefly
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: firefly
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: firefly
+    repoURL: https://github.com/lsst-sqre/charts.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -20,7 +20,7 @@ spec:
   project: default
   source:
     path: landing-page
-    repoURL: https://lsst-sqre.github.io/charts/
+    repoURL: https://github.com/lsst-sqre/charts.git
     targetRevision: HEAD
   syncPolicy:
     automated:

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: landing-page
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: landing-page
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: landing-page
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: landing-page
+    repoURL: https://lsst-sqre.github.io/charts/
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -10,6 +10,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: landing-page
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -10,6 +10,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: tap
+  namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -24,10 +24,10 @@ spec:
     targetRevision: HEAD
     helm:
       parameters:
-      - name: 'slack_webhook_url'
-        value: 'abc'
-      - name: 'google_creds'
-        value: 'def'
+      - name: 'vault_secrets.enabled'
+        value: 'True'
+      - name: 'vault_secrets.path'
+        value: 'secret/k8s_operator/gke/tap'
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -28,6 +28,8 @@ spec:
         value: 'True'
       - name: 'vault_secrets.path'
         value: 'secret/k8s_operator/gke/tap'
+      - name: 'secrets.enabled'
+        value: 'False'
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tap
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tap
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tap
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: cadc-tap
+    repoURL: https://lsst-sqre.github.io/charts/
+    targetRevision: HEAD
+    helm:
+      parameters:
+      - name: 'slack_webhook_url'
+        value: 'abc'
+      - name: 'google_creds'
+        value: 'def'
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -20,7 +20,7 @@ spec:
   project: default
   source:
     path: cadc-tap
-    repoURL: https://lsst-sqre.github.io/charts/
+    repoURL: https://github.com/lsst-sqre/charts.git
     targetRevision: HEAD
     helm:
       parameters:

--- a/science-platform/values-google.yaml
+++ b/science-platform/values-google.yaml
@@ -1,0 +1,3 @@
+cadc-tap:
+  slack_webhook_url: 'YWJjCg=='
+  google_creds: 'YWJjCg=='


### PR DESCRIPTION
This contains apps and helpers for setting up argo-cd on -int, and GKE.  This includes an app and some ideas at different layouts.

Since this is deployed to -int right now, taking this to master.