### PR TITLE
[DM-22328] Add nublado application to -int

### DIFF
--- a/science-platform-int/templates/landing-page-application.yaml
+++ b/science-platform-int/templates/landing-page-application.yaml
@@ -24,7 +24,7 @@ spec:
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/tickets/DM-22180/lsst-lsp-int/landing-page.yaml
+      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/landing-page.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-int/templates/nublado-application.yaml
+++ b/science-platform-int/templates/nublado-application.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lsst-lsp-int-nb
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nublado
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: lsst-lsp-int-nb
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: nublado
+    repoURL: https://github.com/lsst-sqre/charts.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/nublado.yaml
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform-int/templates/tap-application.yaml
+++ b/science-platform-int/templates/tap-application.yaml
@@ -24,7 +24,7 @@ spec:
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/tickets/DM-22180/lsst-lsp-int/cadc-tap.yaml
+      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/cadc-tap.yaml
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
This sets up argocd to control the nublado application (now part of the science-platform-int app of apps), which uses the helm chart that we tested out before.