### PR TITLE
[DM-22330] Point -int back to lsst-demo firefly

### DIFF
--- a/lsst-lsp-int/nublado.yaml
+++ b/lsst-lsp-int/nublado.yaml
@@ -22,6 +22,8 @@ hub:
  
 routes:
   soda: '/api/image/soda'
+  external:
+    firefly: 'https://lsst-demo.ncsa.illinois.edu/firefly'
 
 dask:
   restrict_nodes: 'true'


### PR DESCRIPTION
Okay so due to this bug, GPDF has said we should set nublado back
to using the old firefly demo URL until this linked issue is fixed.