### PR TITLE
[DM-22376] Set argo version to 1.2.4, new signing key for nublado

### DIFF
--- a/argo-cd/lsst-lsp-stable-values.yaml
+++ b/argo-cd/lsst-lsp-stable-values.yaml
@@ -1,6 +1,10 @@
 redis:
   enabled: true
 
+global:
+  image:
+    tag: "v1.2.4"
+
 server:
   ingress:
     enabled: true
@@ -9,7 +13,7 @@ server:
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-stable.ncsa.illinois.edu/auth?capability=exec:admin
+      nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-stable.ncsa.illinois.edu/auth?capability=exec:notebook
       nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/sign_in
       nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
       nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/lsst-lsp-stable/nublado.yaml
+++ b/lsst-lsp-stable/nublado.yaml
@@ -110,3 +110,14 @@ resourcemap: |
         }
       }
   ]
+
+signing_certificate: |
+  -----BEGIN PUBLIC KEY-----
+  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxmOImX9n1nHYlu546Htk
+  E1ghUfnXBnIoCZyZ/FocfWh20+Psi6E2CpSwReEE1O1u9njDwrf8pBqdkcXEJu16
+  czsAqsQr62Fm7WusYC+fRSeKq+kPJ5QB/mCAp3FW0/MFpThjeSeLuPTfQj4AQ8zR
+  9IfWL24LdvQBxGiaGaFMQHgah1ZDcNuABP6a/E2D55Z9c3TYp6UVp0jh+K16Fexj
+  CCAqwixLzon3cdcWmuDV3BU7ULJzcdwA2H35XAIhxuQyJbNq+ybmf+ZZW+rWMhPG
+  I79d2OwyjAqpf3SJKiBOpimK+1Vh/ZcKIPBVT+INfoe9XPcKnFV9csmpFXfgR5gP
+  TwIDAQAB
+  -----END PUBLIC KEY-----


### PR DESCRIPTION
Okay so we found a regression on argocd 1.3.0 where it didn't like
the values files passed in with an explicit full URL for some reason.

Also, nublado stable needs a different signing key for the JWT tokens.