### PR TITLE
[DM-22501] Deploy landing page 3.0 to stable

### DIFF
--- a/lsst-lsp-stable/landing-page.yaml
+++ b/lsst-lsp-stable/landing-page.yaml
@@ -1,5 +1,4 @@
 motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/stable.md
 host: "lsst-lsp-stable.ncsa.illinois.edu"
 image:
-  repository: "mgckind/lsst-lsp-landing"
-  tag: "stable-1.2"
+  tag: "3.0"


### PR DESCRIPTION
This is needed to point at the updated URL for portal which is on
stable.