### PR TITLE
[DM-22518] Refactor argocd apps

### DIFF
--- a/science-platform-int/templates/landing-page-application.yaml
+++ b/science-platform-int/templates/landing-page-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: landing-page
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/landing-page
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/landing-page.yaml
+      - values-int.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-int/templates/nublado-application.yaml
+++ b/science-platform-int/templates/nublado-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: nublado
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/nublado
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/nublado.yaml
+      - values-int.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-int/templates/portal-application.yaml
+++ b/science-platform-int/templates/portal-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: firefly
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/portal
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/portal.yaml
+      - values-int.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-int/templates/tap-application.yaml
+++ b/science-platform-int/templates/tap-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: cadc-tap
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/tap
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-int/cadc-tap.yaml
+      - values-int.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-stable/templates/landing-page-application.yaml
+++ b/science-platform-stable/templates/landing-page-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: landing-page
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/landing-page
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-stable/landing-page.yaml
+      - values-stable.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-stable/templates/nublado-application.yaml
+++ b/science-platform-stable/templates/nublado-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: nublado
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/nublado
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-stable/nublado.yaml
+      - values-stable.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-stable/templates/portal-application.yaml
+++ b/science-platform-stable/templates/portal-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: firefly
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/portal
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-stable/portal.yaml
+      - values-stable.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform-stable/templates/tap-application.yaml
+++ b/science-platform-stable/templates/tap-application.yaml
@@ -19,12 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: cadc-tap
-    repoURL: https://github.com/lsst-sqre/charts.git
+    path: services/tap
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - https://raw.githubusercontent.com/lsst-sqre/lsp-deploy/master/lsst-lsp-stable/cadc-tap.yaml
+      - values-stable.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -21,7 +21,7 @@ spec:
   source:
     path: services/landing-page
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
-    targetRevision: tickets/DM-22518
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/landing-page-application.yaml
+++ b/science-platform/templates/landing-page-application.yaml
@@ -19,9 +19,9 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: landing-page
-    repoURL: https://github.com/lsst-sqre/charts.git
-    targetRevision: HEAD
+    path: services/landing-page
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: tickets/DM-22518
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/nublado-application.yaml
+++ b/science-platform/templates/nublado-application.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nublado
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nublado
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: nublado
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/nublado
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: tickets/DM-22518
+  syncPolicy:
+    automated:
+      prune: true

--- a/science-platform/templates/nublado-application.yaml
+++ b/science-platform/templates/nublado-application.yaml
@@ -21,7 +21,7 @@ spec:
   source:
     path: services/nublado
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
-    targetRevision: tickets/DM-22518
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/portal-application.yaml
+++ b/science-platform/templates/portal-application.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     path: services/portal
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
-    targetRevision: tickets/DM-22518
+    targetRevision: HEAD
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/portal-application.yaml
+++ b/science-platform/templates/portal-application.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: firefly
+  name: portal
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: firefly
+  name: portal
   namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: firefly
+    namespace: portal
     server: https://kubernetes.default.svc
   project: default
   source:

--- a/science-platform/templates/portal-application.yaml
+++ b/science-platform/templates/portal-application.yaml
@@ -16,9 +16,9 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: firefly
-    repoURL: https://github.com/lsst-sqre/charts.git
-    targetRevision: HEAD
+    path: services/portal
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: tickets/DM-22518
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -21,7 +21,7 @@ spec:
   source:
     path: services/tap
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
-    targetRevision: tickets/DM-22518
+    targetRevision: HEAD
     helm:
       valueFiles:
       - values-gke.yaml

--- a/science-platform/templates/tap-application.yaml
+++ b/science-platform/templates/tap-application.yaml
@@ -19,17 +19,12 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: cadc-tap
-    repoURL: https://github.com/lsst-sqre/charts.git
-    targetRevision: HEAD
+    path: services/tap
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: tickets/DM-22518
     helm:
-      parameters:
-      - name: 'vault_secrets.enabled'
-        value: 'True'
-      - name: 'vault_secrets.path'
-        value: 'secret/k8s_operator/gke/tap'
-      - name: 'secrets.enabled'
-        value: 'False'
+      valueFiles:
+      - values-gke.yaml
   syncPolicy:
     automated:
       prune: true

--- a/science-platform/values-google.yaml
+++ b/science-platform/values-google.yaml
@@ -1,3 +1,0 @@
-cadc-tap:
-  slack_webhook_url: 'YWJjCg=='
-  google_creds: 'YWJjCg=='

--- a/services/landing-page/Chart.yaml
+++ b/services/landing-page/Chart.yaml
@@ -1,0 +1,1 @@
+name: landing-page

--- a/services/landing-page/requirements.yaml
+++ b/services/landing-page/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: landing-page
+  version: ">=0.1.0"
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/landing-page/values-int.yaml
+++ b/services/landing-page/values-int.yaml
@@ -1,0 +1,5 @@
+landing-page:
+  motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "lsst-lsp-int.ncsa.illinois.edu"
+  image:
+    tag: "3.0"

--- a/services/landing-page/values-stable.yaml
+++ b/services/landing-page/values-stable.yaml
@@ -1,0 +1,5 @@
+landing-page:
+  motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/stable.md
+  host: "lsst-lsp-stable.ncsa.illinois.edu"
+  image:
+    tag: "3.0"

--- a/services/nublado/Chart.yaml
+++ b/services/nublado/Chart.yaml
@@ -1,0 +1,1 @@
+name: nublado

--- a/services/nublado/requirements.yaml
+++ b/services/nublado/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: nublado
+  version: ">=0.1.0"
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/nublado/values-int.yaml
+++ b/services/nublado/values-int.yaml
@@ -1,0 +1,113 @@
+nublado:
+  fqdn: lsst-lsp-int.ncsa.illinois.edu
+
+  oauth_provider: 'jwt'
+
+  lab:
+    restrict_nodes: 'true'
+    image:
+      experimentals: 2
+      dailies: 2
+
+    resources:
+      cpu_limit: '2.0'
+      mem_limit: '3G'
+      cpu_guarantee: '0.5'
+      mem_guarantee: '512M'
+      nodejs_max_mem: '6144'
+      mb_per_cpu: 3072
+      size_range: "6"
+
+  hub:
+    persistent_home: False
+
+  routes:
+    soda: '/api/image/soda'
+    external:
+      firefly: 'https://lsst-demo.ncsa.illinois.edu/firefly'
+
+  dask:
+    restrict_nodes: 'true'
+
+  vault_secrets:
+    enabled: True
+    path: secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/nublado
+
+  proxy:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:notebook&reissue_token=true
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header X-Forwarded-Proto https;
+          proxy_set_header X-Forwarded-Port 443;
+          proxy_set_header X-Forwarded-Path /nb;
+          auth_request_set $auth_token $upstream_http_x_auth_request_token;
+          proxy_set_header X-Portal-Authorization "Bearer $auth_token";
+          error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
+      host: lsst-lsp-int.ncsa.illinois.edu
+
+  mountpoints: |
+    [
+      { "disabled": true,
+        "mountpoint": "/example -- if it doesn't start with '/' we add it",
+        "fileserver-host": "omit to use Hub settings",
+        "fileserver-export": "defaults to '/exports<mountpoint>'",
+        "mode": "rw or ro, defaults to 'ro'",
+        "options": "mount options, e.g. 'local_lock=all'"
+      },
+      {
+        "disabled": true,
+        "mountpoint": "/n/lsstdata/offline/teststand",
+        "mode": "ro",
+        "kubernetes-volume": "teststand-lsst-lsp-int"
+      },
+      {
+       "mountpoint": "/home",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/jhome"
+      },
+      {
+        "mountpoint": "/datasets",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/datasets"
+      },
+      {
+        "mountpoint": "/project",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/project"
+      },
+      {
+        "mountpoint": "/scratch",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/scratch"
+      },
+      {
+        "mountpoint": "/lsstdata/offline/teststand",
+        "mode": "ro",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/teststand"
+      }
+    ]
+
+  resourcemap: |
+    [
+        { "disabled": true,
+          "user": "Username for user with custom resources",
+          "group": "Groupname for group with custom resources",
+          "resources": {
+              "size_index": "integer representing which size container is default: 0 is smallest",
+              "mem_quota": "integer, namespace quota size in MB",
+              "cpu_quota": "integer, namespace quota CPU limit"
+          }
+        },
+        { "group": "lsst_int_lspdev",
+          "resources": {
+              "size_index": 3,
+              "mem_quota": 626688,
+              "cpu_quota": 204
+          }
+        }
+    ]

--- a/services/nublado/values-stable.yaml
+++ b/services/nublado/values-stable.yaml
@@ -1,0 +1,112 @@
+nublado:
+  fqdn: lsst-lsp-stable.ncsa.illinois.edu
+
+  oauth_provider: 'jwt'
+
+  lab:
+    restrict_nodes: 'true'
+
+    resources:
+      cpu_limit: '2.0'
+      mem_limit: '3G'
+      cpu_guarantee: '0.5'
+      mem_guarantee: '512M'
+      nodejs_max_mem: '6144'
+      mb_per_cpu: 3072
+      size_range: "6"
+
+  hub:
+    persistent_home: False
+
+  routes:
+    soda: '/api/image/soda'
+    external:
+      firefly: 'https://lsst-demo.ncsa.illinois.edu/firefly'
+
+  dask:
+    restrict_nodes: 'true'
+
+  vault_secrets:
+    enabled: True
+    path: secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/nublado
+
+  proxy:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-stable.ncsa.illinois.edu/auth?capability=exec:notebook&reissue_token=true
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header X-Forwarded-Proto https;
+          proxy_set_header X-Forwarded-Port 443;
+          proxy_set_header X-Forwarded-Path /nb;
+          auth_request_set $auth_token $upstream_http_x_auth_request_token;
+          proxy_set_header X-Portal-Authorization "Bearer $auth_token";
+          error_page 403 = "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
+      host: lsst-lsp-stable.ncsa.illinois.edu
+
+  mountpoints: |
+    [
+      { "disabled": true,
+        "mountpoint": "/example -- if it doesn't start with '/' we add it",
+        "fileserver-host": "omit to use Hub settings",
+        "fileserver-export": "defaults to '/exports<mountpoint>'",
+        "mode": "rw or ro, defaults to 'ro'",
+        "options": "mount options, e.g. 'local_lock=all'"
+      },
+      {
+        "disabled": true,
+        "mountpoint": "/n/lsstdata/offline/teststand",
+        "mode": "ro",
+        "kubernetes-volume": "teststand-lsst-lsp-int"
+      },
+      {
+       "mountpoint": "/home",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/jhome"
+      },
+      {
+        "mountpoint": "/datasets",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/datasets"
+      },
+      {
+        "mountpoint": "/project",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/project"
+      },
+      {
+        "mountpoint": "/scratch",
+        "mode": "rw",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/lsst/scratch"
+      },
+      {
+        "mountpoint": "/lsstdata/offline/teststand",
+        "mode": "ro",
+        "fileserver-host": "lsst-nfs.ncsa.illinois.edu",
+        "fileserver-export": "/teststand"
+      }
+    ]
+
+  resourcemap: |
+    [
+      { "group": "lsst_int_lspdev",
+        "resources": {
+            "size_index": 3,
+            "mem_quota": 626688,
+            "cpu_quota": 204
+        }
+      }
+    ]
+
+  signing_certificate: |
+    -----BEGIN PUBLIC KEY-----
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxmOImX9n1nHYlu546Htk
+    E1ghUfnXBnIoCZyZ/FocfWh20+Psi6E2CpSwReEE1O1u9njDwrf8pBqdkcXEJu16
+    czsAqsQr62Fm7WusYC+fRSeKq+kPJ5QB/mCAp3FW0/MFpThjeSeLuPTfQj4AQ8zR
+    9IfWL24LdvQBxGiaGaFMQHgah1ZDcNuABP6a/E2D55Z9c3TYp6UVp0jh+K16Fexj
+    CCAqwixLzon3cdcWmuDV3BU7ULJzcdwA2H35XAIhxuQyJbNq+ybmf+ZZW+rWMhPG
+    I79d2OwyjAqpf3SJKiBOpimK+1Vh/ZcKIPBVT+INfoe9XPcKnFV9csmpFXfgR5gP
+    TwIDAQAB
+    -----END PUBLIC KEY-----

--- a/services/portal/Chart.yaml
+++ b/services/portal/Chart.yaml
@@ -1,0 +1,1 @@
+name: portal

--- a/services/portal/requirements.yaml
+++ b/services/portal/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: firefly
+  version: ">=0.1.0"
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/portal/values-int.yaml
+++ b/services/portal/values-int.yaml
@@ -1,0 +1,54 @@
+firefly:
+  image:
+    tag: "1.1.1"
+
+  ingress:
+    host: 'lsst-lsp-int.ncsa.illinois.edu'
+    annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:portal
+      nginx.ingress.kubernetes.io/configuration-snippet: | 
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-Path /portal/app;
+        error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
+
+  secrets:
+    enabled: False
+
+  vault_secrets:
+    enabled: True
+    path: 'secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/portal'
+
+  max_jvm_size: "23G"
+
+  redis:
+    resources:
+      limits:
+        memory: 20Mi
+
+  nodeSelector:
+    environment: portal-int
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: portal
+
+  resources:
+    limits:
+      memory: 24Gi
+
+  volumes:
+    firefly_workarea:
+      emptyDir: null
+      hostPath:
+        path: /sui/firefly/workarea
+        type: Directory
+    firefly_config:
+      emptyDir: null
+      hostPath:
+        path: /sui/firefly/config
+        type: Directory

--- a/services/portal/values-stable.yaml
+++ b/services/portal/values-stable.yaml
@@ -1,0 +1,54 @@
+firefly:
+  image:
+    tag: "1.1.1"
+
+  ingress:
+    host: 'lsst-lsp-stable.ncsa.illinois.edu'
+    annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-stable.ncsa.illinois.edu/auth?capability=exec:portal
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-Path /portal/app;
+        error_page 403 = "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
+
+  secrets:
+    enabled: False
+
+  vault_secrets:
+    enabled: True
+    path: 'secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/portal'
+
+  max_jvm_size: "23G"
+
+  redis:
+    resources:
+      limits:
+        memory: 20Mi
+
+  nodeSelector:
+    environment: portal-stable
+
+  tolerations:
+  - effect: NoSchedule
+    key: dedicated
+    operator: Equal
+    value: portal
+
+  resources:
+    limits:
+      memory: 24Gi
+
+  volumes:
+    firefly_workarea:
+      emptyDir: null
+      hostPath:
+        path: /sui/firefly/workarea
+        type: Directory
+    firefly_config:
+      emptyDir: null
+      hostPath:
+        path: /sui/firefly/config
+        type: Directory

--- a/services/tap/Chart.yaml
+++ b/services/tap/Chart.yaml
@@ -1,0 +1,1 @@
+name: tap

--- a/services/tap/requirements.yaml
+++ b/services/tap/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: cadc-tap
+  version: ">=0.1.0"
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/tap/values-gke.yaml
+++ b/services/tap/values-gke.yaml
@@ -1,0 +1,10 @@
+cadc-tap:
+  tag: "1.0.1"
+  use_mock_qserv: True
+
+  secrets:
+    enabled: False
+
+  vault_secrets:
+    enabled: True
+    path: 'secret/k8s_operator/gke/tap'

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,0 +1,21 @@
+cadc-tap:
+  tag: "1.0.1"
+  use_mock_qserv: False
+
+  host: "lsst-lsp-int.ncsa.illinois.edu"
+
+  secrets:
+    enabled: False
+
+  vault_secrets:
+    enabled: True
+    path: 'secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/tap'
+
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=read:tap&reissue_token=true
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        error_page 403 = @Basic401; # Basic401 configured in jwt-authorizer ingress rule
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,0 +1,22 @@
+cadc-tap:
+  tag: "1.0"
+  use_mock_qserv: False
+  querymonkey_replicas: 1
+
+  host: "lsst-lsp-stable.ncsa.illinois.edu"
+
+  secrets:
+    enabled: False
+
+  vault_secrets:
+    enabled: True
+    path: 'secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/tap'
+
+  ingress:
+    authenticated_annotations:
+      nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
+      nginx.ingress.kubernetes.io/auth-url: https://lsst-lsp-stable.ncsa.illinois.edu/auth?capability=read:tap&reissue_token=true
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        error_page 403 = @Basic401; # Basic401 configured in jwt-authorizer ingress rule
+        auth_request_set $auth_token $upstream_http_x_auth_request_token;
+        proxy_set_header Authorization "Bearer $auth_token";


### PR DESCRIPTION
Bring in another level of indirection via the services directory.  These directories allow for a place to store helm values.yaml files for different environments altogether by component.  I wanted the organization to be the other way first (environments then applications) but it seems like this model is more native to the way argo expects.  Plus, getting rid of the links should make the gitops checking easier.