### PR TITLE
[DM-22582] Fixing qserv logs

### DIFF
--- a/logging/create.sh
+++ b/logging/create.sh
@@ -4,4 +4,4 @@ set -ex
 helm install stable/elasticsearch --name nordic-bunny --namespace logging --values es-values.yaml
 helm install kiwigrid/fluentd-elasticsearch --name no-turkey --values fluentd-es-values.yaml --namespace logging
 helm install stable/kibana --name ardent-ladybug --values kibana-values.yaml --namespace logging
-kubectl create -f ingress.yaml --namespace logging
+kubectl create -f ingress-int.yaml --namespace logging

--- a/logging/es-values.yaml
+++ b/logging/es-values.yaml
@@ -10,7 +10,7 @@ data:
     enabled: false
     #name: 'pvc-lspelk'
     #size: '100Gi'
-  heapSize: "1g"
+  heapSize: "5g"
   resources:
     limits:
       cpu: "2"
@@ -19,8 +19,8 @@ data:
       cpu: "2"
       memory: 7G
 client:
-  replicas: 12
-  heapSize: "2g"
+  replicas: 8
+  heapSize: "6g"
   resources:
     limits:
       cpu: "2"

--- a/logging/fluentd-es-values.yaml
+++ b/logging/fluentd-es-values.yaml
@@ -13,7 +13,73 @@ extraVolumes:
 extraVolumeMounts:
   - name: qservlogs
     mountPath: /qserv/log
+configMaps:
+  useDefaults:
+    containersInputConf: false
 extraConfigMaps:
+  kubernetes.input.conf: |-
+    <source>
+      @id fluentd-containers.log
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/containers.log.pos
+      tag raw.kubernetes.*
+      read_from_head true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+    # Detect exceptions in the log output and forward them as one log entry.
+    <match raw.kubernetes.**>
+      @id raw.kubernetes
+      @type detect_exceptions
+      remove_tag_prefix raw
+      message log
+      stream stream
+      multiline_flush_interval 5
+      max_bytes 500000
+      max_lines 1000
+    </match>
+    # Concatenate multi-line logs
+    #<filter **>
+    <filter kubernetes.**>
+      @id filter_concat
+      @type concat
+      key message
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+    # Enriches records with Kubernetes metadata
+    <filter kubernetes.**>
+      @id filter_kubernetes_metadata
+      @type kubernetes_metadata
+    </filter>
+    # Fixes json fields in Elasticsearch
+    <filter kubernetes.**>
+      @id filter_parser
+      @type parser
+      key_name log
+      reserve_data true
+      remove_key_name_field true
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+        </pattern>
+        <pattern>
+          format none
+        </pattern>
+      </parse>
+    </filter>
   qserv.conf: |-
     # Example line:
     # 2019-04-24 23:05:29 140240301914240 [Note] InnoDB: 5.7.21 started; log sequence number 28871386

--- a/logging/ingress-int.yaml
+++ b/logging/ingress-int.yaml
@@ -7,7 +7,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-    nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:ops
+    nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:admin
     nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-int.ncsa.illinois.edu/oauth2/sign_in
     nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
     nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
This overrides some configuration from the parent chart, especially having to do with log line concatenation.  While this worked for only kubernetes and docker logs, for qserv it seemed to struggle, so I limited this filter to only the kubernetes logs.