### PR TITLE
[DM-22666] Argocd to manual

### DIFF
--- a/science-platform-int/templates/landing-page-application.yaml
+++ b/science-platform-int/templates/landing-page-application.yaml
@@ -25,6 +25,3 @@ spec:
     helm:
       valueFiles:
       - values-int.yaml
-  syncPolicy:
-    automated:
-      prune: true

--- a/science-platform-int/templates/nublado-application.yaml
+++ b/science-platform-int/templates/nublado-application.yaml
@@ -25,6 +25,3 @@ spec:
     helm:
       valueFiles:
       - values-int.yaml
-  syncPolicy:
-    automated:
-      prune: true

--- a/science-platform-int/templates/portal-application.yaml
+++ b/science-platform-int/templates/portal-application.yaml
@@ -25,6 +25,3 @@ spec:
     helm:
       valueFiles:
       - values-int.yaml
-  syncPolicy:
-    automated:
-      prune: true

--- a/science-platform-int/templates/tap-application.yaml
+++ b/science-platform-int/templates/tap-application.yaml
@@ -25,6 +25,3 @@ spec:
     helm:
       valueFiles:
       - values-int.yaml
-  syncPolicy:
-    automated:
-      prune: true


### PR DESCRIPTION
Apparently having this part in where setting prune to True (the
default is false) also turns on the automated sync.  I don't see
any settings for the manual sync in the CRD definition at:

https://argoproj.github.io/argo-cd/operator-manual/application.yaml

So I hope by taking out this part that it will go to manual mode.