### PR TITLE
[DM-22649] Fix TAP async by using configurable buckets

### DIFF
--- a/services/tap/values-gke.yaml
+++ b/services/tap/values-gke.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.1"
+  tag: "1.0.2"
   use_mock_qserv: True
 
   secrets:
@@ -8,3 +8,6 @@ cadc-tap:
   vault_secrets:
     enabled: True
     path: 'secret/k8s_operator/gke/tap'
+
+  gcs_bucket: 'async-results.lsst.codes'
+  gcs_bucket_url: 'http://async-results.lsst.codes'

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.1"
+  tag: "1.0.2"
   use_mock_qserv: False
 
   host: "lsst-lsp-int.ncsa.illinois.edu"
@@ -35,3 +35,6 @@ cadc-tap:
     limits:
       cpu: 2.0
       memory: 4G
+
+  gcs_bucket: 'async-results.lsst.codes'
+  gcs_bucket_url: 'http://async-results.lsst.codes'

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0"
+  tag: "1.0.2"
   use_mock_qserv: False
   querymonkey_replicas: 1
 
@@ -36,3 +36,6 @@ cadc-tap:
     limits:
       cpu: 2.0
       memory: 4G
+
+  gcs_bucket: 'async-results.lsst.codes'
+  gcs_bucket_url: 'http://async-results.lsst.codes'


### PR DESCRIPTION
Now we can update the values.yaml files with the configuration for
the bucket to use in the helm chart, which now supports setting this
bucket.  This goes right on through to the TAP server as a parameter.