### PR TITLE
[DM-22775] Add helm repo for kiwigrid

### DIFF
--- a/argo-cd/lsst-lsp-int-values.yaml
+++ b/argo-cd/lsst-lsp-int-values.yaml
@@ -27,3 +27,5 @@ server:
         name: lsst-sqre
       - url: https://ricoberger.github.io/helm-charts/
         name: ricoberger
+      - url: https://kiwigrid.github.io/
+        name: kiwigrid

--- a/argo-cd/lsst-lsp-stable-values.yaml
+++ b/argo-cd/lsst-lsp-stable-values.yaml
@@ -31,3 +31,5 @@ server:
         name: lsst-sqre
       - url: https://ricoberger.github.io/helm-charts/
         name: ricoberger
+      - url: https://kiwigrid.github.io/
+        name: kiwigrid


### PR DESCRIPTION
The logging service uses a new helm chart repository for the fluentd
chart.  These need to be explicitly whitelisted in the helm config
for argocd.