### PR TITLE
[DM-22775] One more time on fluentd environment variable

### DIFF
--- a/services/logging/values-int.yaml
+++ b/services/logging/values-int.yaml
@@ -65,8 +65,7 @@ fluentd-elasticsearch:
   elasticsearch:
     host: nordic-bunny-elasticsearch-client
   env:
-    - name: RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
-      value: "0.9"
+    RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: "0.9"
   tolerations:
     - key: "dedicated"
       operator: "Exists"


### PR DESCRIPTION
Okay so with further detailed testing, I had it right to start,
and this line is actually a redherring:

2019/12/31 16:53:18 Warning: Building values map for chart 'fluentd-elasticsearch'. Skipped value (map[]) for 'env', as it is not a table.

It makes it sound like the values-int.yaml is wrong, but looking
at the dry-run output, it is in there.  So this warning must be
generated by something else.  But it looks like it is now injecting
things correctly.