### PR TITLE
[DM-22787] Use new TAP chart to point to qserv-master01:31111

### DIFF
--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,6 +1,7 @@
 cadc-tap:
   tag: "1.0.3"
   use_mock_qserv: False
+  qserv_host: "qserv-master01:4040"
 
   host: "lsst-lsp-int.ncsa.illinois.edu"
 

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,6 +1,8 @@
 cadc-tap:
   tag: "1.0.3"
   use_mock_qserv: False
+  qserv_host: "qserv-master01:4040"
+
   querymonkey_replicas: 1
 
   host: "lsst-lsp-stable.ncsa.illinois.edu"


### PR DESCRIPTION
This uses these values changes to configure where the TAP server
connects to.