### PR TITLE
Fix for application name on auth

### DIFF
--- a/science-platform-int/templates/authnz-application.yaml
+++ b/science-platform-int/templates/authnz-application.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: auth
+  name: authnz
   namespace: argocd
   finalizers:
   - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
This is an attempt to get argo-cd to recognize the auth application.