### PR TITLE
[DM-23863] Increase token session length to 30d

### DIFF
--- a/services/authnz/values-int.yaml
+++ b/services/authnz/values-int.yaml
@@ -24,8 +24,8 @@ authnz:
     # secret/k8s_operator/<host>/jwt_authorizer
     path: "secret/k8s_operator/lsst-lsp-int.ncsa.illinois.edu/jwt_authorizer"
   
-  # Session length/Token expiration (in minutes)
-  session_length: 1440
+  # Session length/Token expiration (in minutes) (30 days)
+  session_length: 43200
   
   # Existing PVC for redis claim
   # If empty, redis will use emptydir

--- a/services/authnz/values-stable.yaml
+++ b/services/authnz/values-stable.yaml
@@ -24,8 +24,8 @@ authnz:
     # secret/k8s_operator/<host>/jwt_authorizer
     path: "secret/k8s_operator/lsst-lsp-stable.ncsa.illinois.edu/jwt_authorizer"
   
-  # Session length/Token expiration (in minutes)
-  session_length: 1440
+  # Session length/Token expiration (in minutes) (30 days)
+  session_length: 43200
   
   # Existing PVC for redis claim
   # If empty, redis will use emptydir


### PR DESCRIPTION
Reflecting a manual change made in stable, tell Argo CD to use
30 days for the token expiration length for internally-created
tokens based on CILogon logins.