### PR TITLE
[DM-23775] Add authnz to nublado

### DIFF
--- a/science-platform/templates/authnz-application.yaml
+++ b/science-platform/templates/authnz-application.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authnz
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: auth
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/authnz
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - values-nublado.yaml

--- a/services/authnz/values-nublado.yaml
+++ b/services/authnz/values-nublado.yaml
@@ -54,7 +54,7 @@ authnz:
     issuer_key_ids: ["244B235F6B28E34108D101EAC7362C4E"]
   
   jwt_authorizer:
-    image: "lsstdm/jwt_authorizer:0.1"
+    image: "lsstdm/jwt_authorizer:0.2.0"
     loglevel: DEBUG
   
     # Defining all capabilites applications may need.

--- a/services/authnz/values-nublado.yaml
+++ b/services/authnz/values-nublado.yaml
@@ -1,0 +1,86 @@
+authnz:
+  secrets:
+    enabled: False
+    # <generated flask secret>
+    flask_secret: "" 
+    # <generated cookie secret>
+    oauth2_proxy_cookie_secret: "" 
+    # <cilogon/OIDC secret>
+    oauth2_proxy_client_secret: "" 
+    # Generating a private key, then public key, then getting url-save version of it all
+    # echo "Generating Issuer Keypair... private.pem, public.pem"
+    # openssl genrsa -out private.pem 2048 2> /dev/null
+    # openssl rsa -in private.pem -outform PEM -pubout -out public.pem
+    # modulus_hex=$(openssl rsa -pubin -inform PEM -modulus -noout -in public.pem | sed 's/Modulus=//')
+    # modulus_urlsafe_b64=$(printf -- "$modulus_hex" | xxd -r -p | $b64 | sed 's/+/-/g;s/\//_/g;s/=//g')
+    signing_key: ""  # JWT Signing Key (private key)
+  
+  
+  host: nublado.lsst.codes
+  
+  vault_secrets:
+    enabled: True
+    # secret/k8s_operator/<host>/jwt_authorizer
+    path: "secret/k8s_operator/nublado.lsst.codes/jwt_authorizer"
+  
+  # Session length/Token expiration (in minutes) (30 days)
+  session_length: 43200
+  
+  # Existing PVC for redis claim
+  # If empty, redis will use emptydir
+  redis_claim: ""
+  
+  
+  #  derived from public key of signing key - $(modulus_urlsafe_b64) from above
+  jwks_n: "0ViEK-a2lQFSTFlO1jn-ta0NsiHh40uIRKAWvXd8eFJjZYK2DhrH9biLB9AkUtyzvcywpYl-_lquwUQBz04ZNJC5ykR1YBzSKicpVvHF8b3I_NNT_aqyOEEkhG6I1_ZKlz03lyOYyKdzNvEoa4yUA2WUdysSsZYXIIo4jh2M1rfsS-ozcDSwWkY1EyGFWsp2fUkDS4qOTTbhxx_TiERkYqT4NRALhvwJA3zJJZXGd-zGl-4rxTl-Xbx6YVHb27ArcQsGK5Ay2HkOqGDkBEZbgYykuPnl3gj_sS0aoxsc4J1mZoU0Ct4qfqaLahUW9kVwnS3vsH-rppdZ-UnK4Rh6xQ"
+  
+  # <client id from cilogon.org or OIDC provider>
+  oauth2_proxy_client_id: "cilogon:/client_id/12fec51db55c36b208dfbe2dee78065c"
+  
+  # Default capability required for user-based operations (like generating a token)
+  user_capability: "exec:user"
+  
+  # Default capability required for admin-based operations (like revoking a token, possibly)
+  admin_capability: "exec:admin"
+  
+  oauth2_proxy:
+    image: "lsstdm/oauth2_proxy:3.2-lsst1"
+    # URLs for oauth2_proxy. This can be simpler, but we need all of them so we can have a
+    # special one for login_url - to include the LSST skin.
+    issuer_url: https://cilogon.org
+    login_url: https://cilogon.org/authorize/?skin=LSST
+    jwks_url: https://cilogon.org/oauth2/certs
+    redeem_url: https://cilogon.org/oauth2/token
+    issuer_key_ids: ["244B235F6B28E34108D101EAC7362C4E"]
+  
+  jwt_authorizer:
+    image: "lsstdm/jwt_authorizer:0.1"
+    loglevel: DEBUG
+  
+    # Defining all capabilites applications may need.
+    # This feeds into the token downlad page
+    known_capabilities:
+      exec:portal: Use the Portal to execute operations. Mostly used from notebook APIs.
+      read:image: Read images from the SODA and other image retrieval interfaces
+      read:image/metadata: Read image metadata from SIA and other image interfaces
+      read:tap: Execute SELECT queries in the TAP interface on project datasets
+      read:tap/efd: Execute SELECT queries in the TAP interface on EFD datasets
+      read:tap/user: Execute SELECT queries in the TAP interface on your data
+      write:tap/user: Upload tables to your database workspace
+      read:tap/history: Read the history of your TAP queries.
+      read:workspace: Read project datasets from the file workspace
+      read:workspace/user: Read the data in your file workspace
+      write:workspace/user: Write data to your file workspace
+  
+  
+    # Mapping of capabilities to groups that are part of the `isMemberOf` claim
+    group_mapping:
+      exec:admin: ["lsst_int_lsp_admin"]
+      exec:user: ["lsst_int_lspdev"]
+      read:workspace: ["lsst_int_lspdev"]
+      read:workspace/user: ["lsst_int_lspdev"]
+      write:workspace/user: ["lsst_int_lspdev"]
+      exec:portal: ["lsst_int_lspdev"]
+      exec:notebook: ["lsst_int_lspdev"]
+      read:tap: ["lsst_int_lspdev"]
+      read:image: ["lsst_int_lspdev"]


### PR DESCRIPTION
Deploy authnz on nublado.  This will install it and configure its
routes, but not put it in front of anything (including the LSP).
It will be used for test deployments and iterative development of
the authnz platform.