### PR TITLE
[DM-23775] Adjust authnz for new Helm chart

### DIFF
--- a/services/authnz/values-int.yaml
+++ b/services/authnz/values-int.yaml
@@ -18,6 +18,8 @@ authnz:
   
   # lsst-lsp-<instance>.ncsa.illinois.edu
   host: lsst-lsp-int.ncsa.illinois.edu
+  ingress:
+    host: lsst-lsp-int.ncsa.illinois.edu
   
   vault_secrets:
     enabled: True

--- a/services/authnz/values-nublado.yaml
+++ b/services/authnz/values-nublado.yaml
@@ -15,7 +15,10 @@ authnz:
     # modulus_urlsafe_b64=$(printf -- "$modulus_hex" | xxd -r -p | $b64 | sed 's/+/-/g;s/\//_/g;s/=//g')
     signing_key: ""  # JWT Signing Key (private key)
   
-  
+
+  # Do not specify ingress.host because we're using the wildcard virtual host.
+  host: nublado.lsst.codes
+
   vault_secrets:
     enabled: True
     # secret/k8s_operator/<host>/jwt_authorizer

--- a/services/authnz/values-stable.yaml
+++ b/services/authnz/values-stable.yaml
@@ -18,6 +18,8 @@ authnz:
   
   # lsst-lsp-<instance>.ncsa.illinois.edu
   host: lsst-lsp-stable.ncsa.illinois.edu
+  ingress:
+    host: lsst-lsp-stable.ncsa.illinois.edu
   
   vault_secrets:
     enabled: True


### PR DESCRIPTION
Specify both host and ingress.host for NCSA deployments, and add
host but not ingress.host for nublado.lsst.codes.