### PR TITLE
[DM-23645] Argo CD management of authnz on stable

### DIFF
--- a/science-platform-stable/templates/authnz-application.yaml
+++ b/science-platform-stable/templates/authnz-application.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authnz
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: auth
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/authnz
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+      - values-stable.yaml

--- a/services/authnz/values-stable.yaml
+++ b/services/authnz/values-stable.yaml
@@ -31,7 +31,7 @@ authnz:
   
   # Existing PVC for redis claim
   # If empty, redis will use emptydir
-  redis_claim: ""
+  redis_claim: "auth-redis-volume-claim"
   
   
   #  derived from public key of signing key - $(modulus_urlsafe_b64) from above

--- a/services/authnz/values-stable.yaml
+++ b/services/authnz/values-stable.yaml
@@ -57,7 +57,7 @@ authnz:
     issuer_key_ids: ["244B235F6B28E34108D101EAC7362C4E"]
   
   jwt_authorizer:
-    image: "lsstdm/jwt_authorizer:0.1"
+    image: "lsstdm/jwt_authorizer:0.2.2"
     loglevel: DEBUG
   
     # Defining all capabilites applications may need.


### PR DESCRIPTION
Enable Argo CD management of authnz on stable, and upgrade stable
to the new release matching the current int deployment. Switch stable to
using a persistent volume claim for Redis.