### PR TITLE
[DM-23776] Protect Nublado with Gafaelfawr

### DIFF
--- a/science-platform/templates/gafaelfawr-application.yaml
+++ b/science-platform/templates/gafaelfawr-application.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: auth
+  name: gafaelfawr
 spec:
   finalizers:
     - kubernetes
@@ -9,19 +9,19 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: authnz
+  name: gafaelfawr
   namespace: argocd
   finalizers:
-  - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: auth
+    namespace: gafaelfawr
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: services/authnz
+    path: services/gafaelfawr
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: HEAD
     helm:
       valueFiles:
-      - values-nublado.yaml
+        - values-nublado.yaml

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -1,0 +1,1 @@
+name: gafaelfawr

--- a/services/gafaelfawr/requirements.yaml
+++ b/services/gafaelfawr/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: gafaelfawr
+  version: "0.1.0"
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/gafaelfawr/values-nublado.yaml
+++ b/services/gafaelfawr/values-nublado.yaml
@@ -1,0 +1,22 @@
+gafaelfawr:
+  host: nublado.lsst.codes
+
+  # Do not specify ingress.host because we're using the wildcard virtual host.
+
+  vault_secrets:
+    path: "secret/k8s_operator/nublado.lsst.codes/jwt_authorizer"
+
+  # Session length/Token expiration (in minutes) (30 days)
+  session_length: 43200
+
+  # CILogon client ID.  Currently not used because we use GitHub instead,
+  # but it's registered, and we may switch to it in the future.
+  oauth2_proxy_client_id: "cilogon:/client_id/12fec51db55c36b208dfbe2dee78065c"
+
+  # Use the PR branch that supports GitHub.
+  image: "lsstdm/jwt_authorizer:tickets-DM-23776"
+
+  # Use GitHub authentication.
+  config:
+    github:
+      client_id: a19e79298a352f3e5650

--- a/services/nublado/values-nublado.yaml
+++ b/services/nublado/values-nublado.yaml
@@ -1,7 +1,7 @@
 nublado:
   fqdn: nublado.lsst.codes
 
-  oauth_provider: 'github'
+  oauth_provider: 'jwt'
 
   hub:
     image: 'lsstsqre/sciplat-hub:latest'
@@ -32,6 +32,21 @@ nublado:
   vault_secrets:
     enabled: True
     path: secret/k8s_operator/nublado.lsst.codes/nublado
+
+  proxy:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/auth-request-redirect: $request_uri
+        nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
+        nginx.ingress.kubernetes.io/auth-signin: https://nublado.lsst.codes/login
+        nginx.ingress.kubernetes.io/auth-url: https://nublado.lsst.codes/auth?capability=exec:notebook
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header X-Forwarded-Proto https;
+          proxy_set_header X-Forwarded-Port 443;
+          proxy_set_header X-Forwarded-Path /nb;
+          auth_request_set $auth_token $upstream_http_x_auth_request_token;
+          proxy_set_header X-Portal-Authorization "Bearer $auth_token";
+      host: nublado.lsst.codes
 
   mountpoints: |
     [


### PR DESCRIPTION
Deploy Gafaelfawr instead of authnz on nublado.lsst.codes and
switch to protecting nublado with it.  Deploy from the PR branch
for now while code review is in progress.