### PR TITLE
[DM-23877] Switch to CILogon authentication

### DIFF
--- a/services/gafaelfawr/requirements.yaml
+++ b/services/gafaelfawr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-- name: gafaelfawr
-  version: 0.1.7
-  repository: https://lsst-sqre.github.io/charts/
+  - name: gafaelfawr
+    version: 0.2.0
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/gafaelfawr/values-nublado.yaml
+++ b/services/gafaelfawr/values-nublado.yaml
@@ -9,25 +9,14 @@ gafaelfawr:
   # Session length/Token expiration (in minutes) (30 days)
   session_length: 43200
 
-  # CILogon client ID.  Currently not used because we use GitHub instead,
-  # but it's registered, and we may switch to it in the future.
-  oauth2_proxy_client_id: "cilogon:/client_id/12fec51db55c36b208dfbe2dee78065c"
-
   # Use the PR branch that supports GitHub.
-  image: "lsstdm/jwt_authorizer:tickets-DM-23776"
+  image: "lsstdm/jwt_authorizer:tickets-DM-23877"
 
-  # Use GitHub authentication.
   config:
-    github:
-      client_id: a19e79298a352f3e5650
+    # Disabled but kept so that the client ID is easily accessible.
+    #github:
+    #  client_id: a19e79298a352f3e5650
 
-    group_mapping:
-      "exec:admin": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "exec:user": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "read:workspace": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "read:workspace/user": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "write:workspace/user": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "exec:portal": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "exec:notebook": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "read:tap": ["lsst-dm-data-management", "lsst-sqre-square"]
-      "read:image": ["lsst-dm-data-management", "lsst-sqre-square"]
+    # Use CILogon authentication.
+    cilogon:
+      client_id: "cilogon:/client_id/12fec51db55c36b208dfbe2dee78065c"


### PR DESCRIPTION
Use the new Gafaelfawr Helm chart and switch to CILogon
authentication from GitHub.  This allows returning to the default
group mappings.