### PR TITLE
[DM-24542] Point int logging to branch

### DIFF
--- a/science-platform-int/templates/logging-application.yaml
+++ b/science-platform-int/templates/logging-application.yaml
@@ -21,7 +21,7 @@ spec:
   source:
     path: services/logging
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
-    targetRevision: HEAD
+    targetRevision: tickets/DM-24542
     helm:
       valueFiles:
       - values-int.yaml


### PR DESCRIPTION
Point logging to this branch.  This will allow me to work on -int's
values file for the new set of charts without disrupting stable or
other environments.  This will be a bit of a tricky dance, since I
am worried a bit about backward compability, but only while I work
on this (and have to have it checked in).