### PR TITLE
[DM-23877] Fix token expiration configuration

### DIFF
--- a/services/gafaelfawr/values-nublado.yaml
+++ b/services/gafaelfawr/values-nublado.yaml
@@ -9,7 +9,7 @@ gafaelfawr:
 
   # Session length and token expiration (in minutes).
   issuer:
-    exp_minues: 43200  # 30 days
+    exp_minutes: 43200  # 30 days
 
   # Disabled but kept so that the client ID is easily accessible.
   #github:


### PR DESCRIPTION
A typo in values-nublado.yaml prevented the setting from being
properly applied.