### PR TITLE
[DM-24595] Remove auth from int Argo CD

### DIFF
--- a/argo-cd/lsst-lsp-int-values.yaml
+++ b/argo-cd/lsst-lsp-int-values.yaml
@@ -13,11 +13,6 @@ server:
     annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-      nginx.ingress.kubernetes.io/auth-url:               https://lsst-lsp-int.ncsa.illinois.edu/auth?capability=exec:admin
-      nginx.ingress.kubernetes.io/auth-sign-in:           https://lsst-lsp-int.ncsa.illinois.edu/oauth2/sign_in
-      nginx.ingress.kubernetes.io/auth-response-headers:  X-Auth-Request-Token
-      nginx.ingress.kubernetes.io/configuration-snippet: |
-       error_page 403 = "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/start?rd=$request_uri";
     paths:
     - /argo-cd(/|$)(.*)
 


### PR DESCRIPTION
Temporarily remove authnz from in front of the Argo CD console on
int.  Port forwarding does not work properly to access the console
for that version of Argo CD, which makes it unsafe to upgrade auth
with auth in front of the UI.  This is behind a VPN and has its own
separate password, so this should be safe as a temporary measure
until the upgrade is complete.