### PR TITLE
[DM-24598] Add rewrite for /logout

### DIFF
--- a/services/gafaelfawr/templates/logout-ingress.yaml
+++ b/services/gafaelfawr/templates/logout-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: "/logout"
+  name: gafaelfawr-logout-ingress
+spec:
+  rules:
+{{ if .Values.gafaelfawr.ingress.host }}
+  - host: {{ .Values.gafaelfawr.ingress.host }}
+    http:
+{{ else }}
+  - http:
+{{ end }}
+      paths:
+      - path: /oauth2/sign_in
+        backend:
+          serviceName: gafaelfawr-service
+          servicePort: 8080


### PR DESCRIPTION
The old nublado logout sent the user to /oauth2/sign_in.  Intercept
that and send it to /logout.