### PR TITLE
[DM-24662] Add login_params, force IdP on nublado.lsst.codes

### DIFF
--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -17,3 +17,5 @@ gafaelfawr:
   cilogon:
     client_id: "cilogon:/client_id/6ca7b54ac075b65bccb9c885f9ba4a75"
     redirect_url: "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/callback"
+    login_params:
+      skin: "LSST"

--- a/services/gafaelfawr/values-nts.yaml
+++ b/services/gafaelfawr/values-nts.yaml
@@ -16,3 +16,5 @@ gafaelfawr:
   # Use CILogon authentication.
   cilogon:
     client_id: "cilogon:/client_id/5d4d96afd3f1acf896a2b5a7a2e94277"
+    login_params:
+      skin: "LSST"

--- a/services/gafaelfawr/values-nublado.yaml
+++ b/services/gafaelfawr/values-nublado.yaml
@@ -16,3 +16,6 @@ gafaelfawr:
   cilogon:
     client_id: "cilogon:/client_id/12fec51db55c36b208dfbe2dee78065c"
     redirect_url: "https://nublado.lsst.codes/oauth2/callback"
+    login_params:
+      skin: "LSST"
+      selected_idp: "https://idp.ncsa.illinois.edu/idp/shibboleth"

--- a/services/gafaelfawr/values-stable.yaml
+++ b/services/gafaelfawr/values-stable.yaml
@@ -17,3 +17,5 @@ gafaelfawr:
   cilogon:
     client_id: "cilogon:/client_id/7ae419868b97e81644ced9886ffbcec"
     redirect_url: "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/callback"
+    login_params:
+      skin: "LSST"


### PR DESCRIPTION
Add login_params settings to all Gafaelfawr deployments since the
new Gafaelfawr chart doesn't force the skin: "LSST" setting.
    
Force the IdP to NCSA for nublado.lsst.codes.  If this works, we'll
do the same for the other environments.
