### PR TITLE
[DM-24662] Set default Gafaelfawr IdP to NCSA

### DIFF
--- a/services/gafaelfawr/values-int.yaml
+++ b/services/gafaelfawr/values-int.yaml
@@ -19,3 +19,4 @@ gafaelfawr:
     redirect_url: "https://lsst-lsp-int.ncsa.illinois.edu/oauth2/callback"
     login_params:
       skin: "LSST"
+      selected_idp: "https://idp.ncsa.illinois.edu/idp/shibboleth"

--- a/services/gafaelfawr/values-nts.yaml
+++ b/services/gafaelfawr/values-nts.yaml
@@ -18,3 +18,4 @@ gafaelfawr:
     client_id: "cilogon:/client_id/5d4d96afd3f1acf896a2b5a7a2e94277"
     login_params:
       skin: "LSST"
+      selected_idp: "https://idp.ncsa.illinois.edu/idp/shibboleth"

--- a/services/gafaelfawr/values-stable.yaml
+++ b/services/gafaelfawr/values-stable.yaml
@@ -19,3 +19,4 @@ gafaelfawr:
     redirect_url: "https://lsst-lsp-stable.ncsa.illinois.edu/oauth2/callback"
     login_params:
       skin: "LSST"
+      selected_idp: "https://idp.ncsa.illinois.edu/idp/shibboleth"


### PR DESCRIPTION
This worked well on nublado.lsst.codes.  The IdP selection screen
is still shown, but NCSA is selected as the default.  Update the
other Gafaelfawr environments to have the same configuration.