### PR TITLE
[DM-24753] Enable 403 handling for nublado.lsst.codes

### DIFF
--- a/services/gafaelfawr/requirements.yaml
+++ b/services/gafaelfawr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: gafaelfawr
-    version: 1.1.0
+    version: 1.2.0
     repository: https://lsst-sqre.github.io/charts/

--- a/services/nublado/values-nublado.yaml
+++ b/services/nublado/values-nublado.yaml
@@ -46,6 +46,7 @@ nublado:
           proxy_set_header X-Forwarded-Path /nb;
           auth_request_set $auth_token $upstream_http_x_auth_request_token;
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
+          error_page 403 = "/auth/forbidden?scope=exec:notebook";
 
   mountpoints: |
     [


### PR DESCRIPTION
Use the new custom error page to suppress caching of 403 errors for
Nublado on nublado.lsst.codes.  If this works properly, it will
later be rolled out to other environments.