### PR TITLE
[DM-24922] Update GitHub client_id for Tucson teststand

### DIFF
--- a/services/gafaelfawr/values-tucson-teststand.yaml
+++ b/services/gafaelfawr/values-tucson-teststand.yaml
@@ -10,7 +10,7 @@ gafaelfawr:
 
   # Use GitHub authentication.
   github:
-    client_id: 9386e0eea5822feba03d
+    client_id: 49533cbd8a8079730dcf
 
   # Allow access by GitHub team.
   group_mapping:


### PR DESCRIPTION
The old one was owned by an individual.  Replace the OAuth
integration with a new client owned by lsst-sqre.