### PR TITLE
[DM-25185] Fix nginx-ingress to point to values files

### DIFF
--- a/science-platform/templates/nginx-ingress-application.yaml
+++ b/science-platform/templates/nginx-ingress-application.yaml
@@ -23,4 +23,7 @@ spec:
     path: services/nginx-ingress
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: {{ .Values.nginx_ingress.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
 {{- end -}}

--- a/services/nginx-ingress/values-nublado.yaml
+++ b/services/nginx-ingress/values-nublado.yaml
@@ -1,0 +1,7 @@
+nginx-ingress:
+  controller:
+    extraArgs.default-ssl-certificate: default/tls-certificate
+    service.omitClusterIP: true
+    stats.service.omitClusterIP: true
+    metrics.service.omitClusterIP: true
+  defaultBackend.service.omitClusterIP: true


### PR DESCRIPTION
Forgot to add this part which points to the proper helm values
files.  This was preventing usage of the SSL certificate.