### PR TITLE
[DM-24810] Use full X-Forwarded-For on bleed

### DIFF
--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -2,6 +2,10 @@ nginx-ingress:
   controller:
     extraArgs:
       default-ssl-certificate: default/tls-certificate
+    config:
+      entries:
+        compute-full-forwarded-for: "true"
+        use-forwarded-headers: "true"
     service:
       omitClusterIP: true
     stats:


### PR DESCRIPTION
Configure bleed to send full X-Forwarded-For headers to debug the
Gafaelfawr support for proper client IP address logging.