### PR TITLE
[DM-24810] Fix syntax of nginx-ingress config

### DIFF
--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -3,9 +3,8 @@ nginx-ingress:
     extraArgs:
       default-ssl-certificate: default/tls-certificate
     config:
-      entries:
-        compute-full-forwarded-for: "true"
-        use-forwarded-headers: "true"
+      compute-full-forwarded-for: "true"
+      use-forwarded-headers: "true"
     service:
       omitClusterIP: true
     stats:


### PR DESCRIPTION
The documentation I found was confusing.  controller.config should
contain the configmap entries directly.