### PR TITLE
[DM-24810] Set externalTrafficPolicy Local on ingress

### DIFF
--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -7,6 +7,7 @@ nginx-ingress:
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true
+      externalTrafficPolicy: Local
     stats:
       service:
         omitClusterIP: true


### PR DESCRIPTION
On the bleed NGINX ingress, set externalTrafficPolicy Local to
try to preserve source IP addresses.