### PR TITLE
[DM-25183] Add required Helm chart metadata

### DIFF
--- a/science-platform-base/Chart.yaml
+++ b/science-platform-base/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-base
+version: 1.0.0

--- a/science-platform-int/Chart.yaml
+++ b/science-platform-int/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-int
+version: 1.0.0

--- a/science-platform-nts/Chart.yaml
+++ b/science-platform-nts/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-nts
+version: 1.0.0

--- a/science-platform-stable/Chart.yaml
+++ b/science-platform-stable/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-stable
+version: 1.0.0

--- a/science-platform-summit/Chart.yaml
+++ b/science-platform-summit/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-summit
+version: 1.0.0

--- a/science-platform-tucson-teststand/Chart.yaml
+++ b/science-platform-tucson-teststand/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: science-platform-tucson-teststand
+version: 1.0.0

--- a/science-platform/Chart.yaml
+++ b/science-platform/Chart.yaml
@@ -1,1 +1,3 @@
+apiVerison: v1
 name: science-platform
+verison: 1.0.0

--- a/services/gafaelfawr/Chart.yaml
+++ b/services/gafaelfawr/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: gafaelfawr
+version: 1.0.0

--- a/services/landing-page/Chart.yaml
+++ b/services/landing-page/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: landing-page
+version: 1.0.0

--- a/services/logging/Chart.yaml
+++ b/services/logging/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: logging
+version: 1.0.0

--- a/services/nginx-ingress/Chart.yaml
+++ b/services/nginx-ingress/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: nginx-ingress
+version: 1.0.0

--- a/services/nublado-users/Chart.yaml
+++ b/services/nublado-users/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: nublado-users
+version: 1.0.0

--- a/services/nublado/Chart.yaml
+++ b/services/nublado/Chart.yaml
@@ -1,2 +1,3 @@
+apiVersion: v1
 name: nublado
 version: 0.0.1

--- a/services/obstap/Chart.yaml
+++ b/services/obstap/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: obstap
+version: 1.0.0

--- a/services/portal/Chart.yaml
+++ b/services/portal/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: portal
+version: 1.0.0

--- a/services/postgres/Chart.yaml
+++ b/services/postgres/Chart.yaml
@@ -1,2 +1,3 @@
+apiVersion: v1
 name: postgres
 version: 0.0.1

--- a/services/tap/Chart.yaml
+++ b/services/tap/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: tap
+version: 1.0.0

--- a/services/vault-secrets-operator/Chart.yaml
+++ b/services/vault-secrets-operator/Chart.yaml
@@ -1,1 +1,3 @@
+apiVersion: v1
 name: vault-secrets-operator
+version: 1.0.0

--- a/services/wf/Chart.yaml
+++ b/services/wf/Chart.yaml
@@ -1,2 +1,3 @@
+apiVersion: v1
 name: wf
 version: 0.0.1


### PR DESCRIPTION
Add required metadata so that Renovate can parse the Helm charts
and look for dependencies that require updates.