### PR TITLE
[DM-25487] Add cert-manager to non-NCSA deployments

### DIFF
--- a/science-platform/templates/cert-manager-application.yaml
+++ b/science-platform/templates/cert-manager-application.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.cert_manager.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: cert-manager
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/cert-manager
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.cert_manager.revision }}
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - "/webhooks/0/clientConfig/caBundle"
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - "/webhooks/0/clientConfig/caBundle"
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -2,6 +2,8 @@ environment: base
 
 argo:
   enabled: true
+cert_manager:
+  enabled: true
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-bleed.yaml
+++ b/science-platform/values-bleed.yaml
@@ -2,6 +2,8 @@ environment: bleed
 
 argo:
   enabled: true
+cert_manager:
+  enabled: true
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -2,6 +2,8 @@ environment: int
 
 argo:
   enabled: true
+cert_manager:
+  enabled: false
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -2,6 +2,8 @@ environment: nts
 
 argo:
   enabled: true
+cert_manager:
+  enabled: false
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-nublado.yaml
+++ b/science-platform/values-nublado.yaml
@@ -2,6 +2,8 @@ environment: nublado
 
 argo:
   enabled: true
+cert_manager:
+  enabled: true
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -2,6 +2,8 @@ environment: stable
 
 argo:
   enabled: true
+cert_manager:
+  enabled: false
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -2,6 +2,8 @@ environment: nts
 
 argo:
   enabled: true
+cert_manager:
+  enabled: true
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -2,6 +2,8 @@ environment: tucson-teststand
 
 argo:
   enabled: true
+cert_manager:
+  enabled: true
 gafaelfawr:
   enabled: true
 landing_page:

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -3,6 +3,9 @@ environment: gke
 argo:
   enabled: true
   revision: HEAD
+cert_manager:
+  enabled: false
+  revision: HEAD
 gafaelfawr:
   enabled: true
   revision: HEAD

--- a/services/cert-manager/Chart.yaml
+++ b/services/cert-manager/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: cert-manager
+version: 1.0.0

--- a/services/cert-manager/requirements.yaml
+++ b/services/cert-manager/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: cert-manager
+  version: v0.15.1
+  repository: https://charts.jetstack.io

--- a/services/cert-manager/templates/cluster-issuer.yaml
+++ b/services/cert-manager/templates/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: cert-manager-letsencrypt-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: sqre-admin@lists.lsst.org
+    privateKeySecretRef:
+      name: cert-manager-letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/services/cert-manager/values.yaml
+++ b/services/cert-manager/values.yaml
@@ -1,0 +1,2 @@
+cert-manager:
+  installCRDs: true


### PR DESCRIPTION
Prepare to use LetsEncrypt to issue certificates rather than using
the wildcard certificate by adding cert-manager to non-NCSA
deployments.  (NCSA uses their own process for certs.)  This will
not do anything as configured until we change Ingress resources to
use the cert-manager annotations for certificates and remove the
nginx-ingress configuration for the default TLS certificate.