### PR TITLE
Move cert-manager application into argocd namespace

### DIFF
--- a/science-platform/templates/cert-manager-application.yaml
+++ b/science-platform/templates/cert-manager-application.yaml
@@ -11,7 +11,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cert-manager
-  namespace: cert-manager
+  namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
All the applications need to be in the argocd namespace or really
weird things happen.