### PR TITLE
[DM-25487] Generate a default certificate

### DIFF
--- a/science-platform/templates/cert-manager-application.yaml
+++ b/science-platform/templates/cert-manager-application.yaml
@@ -23,6 +23,9 @@ spec:
     path: services/cert-manager
     repoURL: https://github.com/lsst-sqre/lsp-deploy.git
     targetRevision: {{ .Values.cert_manager.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
   ignoreDifferences:
     - group: admissionregistration.k8s.io
       kind: MutatingWebhookConfiguration

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -1,4 +1,4 @@
-environment: nts
+environment: summit
 
 argo:
   enabled: true

--- a/services/cert-manager/README.md
+++ b/services/cert-manager/README.md
@@ -1,0 +1,6 @@
+# cert-manager
+
+Set up cert-manager for a Science Platform environment.
+Only used in environments where we control our own certificates.
+This Helm chart, in addition to installing the upstream cert-manager Helm chart, creates a Let's Encrypt issuer and a certificate for the `fqdn` value configured in the environment-specific `values-*.yaml`.
+The resulting secret is `default-certificate` and can be referenced in the configuration of the `nginx-ingress` chart.

--- a/services/cert-manager/templates/default-certificate.yaml
+++ b/services/cert-manager/templates/default-certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: default-certificate
+spec:
+  secretName: default-certificate
+  dnsNames:
+    - {{ .Values.fqdn }}
+  issuerRef:
+    name: cert-manager-letsencrypt-issuer
+    kind: ClusterIssuer

--- a/services/cert-manager/values-base.yaml
+++ b/services/cert-manager/values-base.yaml
@@ -1,0 +1,3 @@
+fqdn: base-lsp.lsst.codes
+cert-manager:
+  installCRDs: true

--- a/services/cert-manager/values-bleed.yaml
+++ b/services/cert-manager/values-bleed.yaml
@@ -1,2 +1,3 @@
+fqdn: bleed.lsst.codes
 cert-manager:
   installCRDs: true

--- a/services/cert-manager/values-nublado.yaml
+++ b/services/cert-manager/values-nublado.yaml
@@ -1,0 +1,3 @@
+fqdn: nublado.lsst.codes
+cert-manager:
+  installCRDs: true

--- a/services/cert-manager/values-summit.yaml
+++ b/services/cert-manager/values-summit.yaml
@@ -1,0 +1,3 @@
+fqdn: summit-lsp.lsst.codes
+cert-manager:
+  installCRDs: true

--- a/services/cert-manager/values-tucson-teststand.yaml
+++ b/services/cert-manager/values-tucson-teststand.yaml
@@ -1,0 +1,3 @@
+fqdn: tucson-teststand.lsst.codes
+cert-manager:
+  installCRDs: true


### PR DESCRIPTION
Tell cert-manager to generate a default certificate

For those environments where we deploy cert-manager, configure
creation of a default certificate in the default-certificate secret.
This requires parameterizing the values.yaml file by environment to
set different FQDNs.

This change does not yet make nginx-ingress use that certificate.
That will be done in a subsequent change.