### PR TITLE
[DM-25487] Switch nublado.lsst.codes to LE certificate

### DIFF
--- a/services/nginx-ingress/values-nublado.yaml
+++ b/services/nginx-ingress/values-nublado.yaml
@@ -1,7 +1,7 @@
 nginx-ingress:
   controller:
     extraArgs:
-      default-ssl-certificate: default/tls-certificate
+      default-ssl-certificate: cert-manager/default-certificate
     service:
       omitClusterIP: true
     stats:


### PR DESCRIPTION
Change the default certificate to the Let's Encrypt issued
certificate for nublado.lsst.codes.