### PR TITLE
[DM-25487] Update apiVersion of ClusterIssuer

### DIFF
--- a/services/cert-manager/templates/cluster-issuer.yaml
+++ b/services/cert-manager/templates/cluster-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha3
 kind: ClusterIssuer
 metadata:
   name: cert-manager-letsencrypt-issuer


### PR DESCRIPTION
See if this is the reason why Argo CD doesn't think the resource
exists even though it does.  The mutating webhook changes the
apiVersion to v1alpha3, and it looks like we can use that version
from the start.