### PR TITLE
[DM-25487] Upgrade nginx-ingress to 1.40.1

### DIFF
--- a/services/nginx-ingress/requirements.yaml
+++ b/services/nginx-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: nginx-ingress
-  version: 1.39.1
+  version: 1.40.1
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Only affects bleed and nublado.lsst.codes for now, so we can test it there and then upgrade other environments as they're subsumed into the new framework.