### PR TITLE
[DM-25487] Manage nginx-ingress on Tucson teststand

### DIFF
--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -13,7 +13,7 @@ logging:
 mobu:
   enabled: false
 nginx_ingress:
-  enabled: false
+  enabled: true
 nublado:
   enabled: true
 obstap:

--- a/services/nginx-ingress/values-tucson-teststand.yaml
+++ b/services/nginx-ingress/values-tucson-teststand.yaml
@@ -1,0 +1,23 @@
+nginx-ingress:
+  controller:
+    extraArgs:
+      default-ssl-certificate: cert-manager/default-certificate
+    config:
+      compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
+      use-forwarded-headers: "true"
+    service:
+      omitClusterIP: true
+      externalTrafficPolicy: Local
+    stats:
+      service:
+        omitClusterIP: true
+    metrics:
+      service:
+        omitClusterIP: true
+  defaultBackend:
+    service:
+      omitClusterIP: true


### PR DESCRIPTION
Take over management of nginx-ingress on the Tucson teststand,
and switch from the wildcard certificate to the Let's Encrypt
certificate.