### PR TITLE
[DM-25183] Enable WhiteSource Renovate for this repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}


### PR DESCRIPTION
Enable Renovate scanning, which will pick up outdated Helm chart
dependencies.