### PR TITLE
Revert "Update helm chart vault-secrets-operator to v1.7.1"

### DIFF
--- a/services/vault-secrets-operator/requirements.yaml
+++ b/services/vault-secrets-operator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: vault-secrets-operator
-  version: 1.7.1
+  version: 1.4.0
   repository: https://ricoberger.github.io/helm-charts/


### PR DESCRIPTION
This reverts commit e6a1c843214cc2012284731eedcdbc0bda37a8b0.
Argo CD reports an error:

map: map[] does not contain declared merge key: name