### PR TITLE
[DM-25730] Remove callback url

### DIFF
--- a/services/gafaelfawr/values-gold-leader.yaml
+++ b/services/gafaelfawr/values-gold-leader.yaml
@@ -15,6 +15,5 @@ gafaelfawr:
   # Use CILogon authentication.
   cilogon:
     client_id: "cilogon:/client_id/537ab5b211d0ddacb05964e5adf9a4dc"
-    redirect_url: "https://gold-leader.lsst.codes/oauth2/callback"
     login_params:
       skin: "LSST"

--- a/services/gafaelfawr/values-red-five.yaml
+++ b/services/gafaelfawr/values-red-five.yaml
@@ -15,6 +15,5 @@ gafaelfawr:
   # Use CILogon authentication.
   cilogon:
     client_id: "cilogon:/client_id/51ea95a5fac24d5a6f33e658d7d77d2a"
-    redirect_url: "https://red-five.lsst.codes/oauth2/callback"
     login_params:
       skin: "LSST"

--- a/services/gafaelfawr/values-rogue-two.yaml
+++ b/services/gafaelfawr/values-rogue-two.yaml
@@ -15,6 +15,5 @@ gafaelfawr:
   # Use CILogon authentication.
   cilogon:
     client_id: "cilogon:/client_id/15352006fec091e45e1425bce7c3c352"
-    redirect_url: "https://rogue-two.lsst.codes/oauth2/callback"
     login_params:
       skin: "LSST"


### PR DESCRIPTION
Apparently this was wrong, what I want is the default which uses the
/login endpoint.  If this is set, then it uses that URL, which isn't
configured in the CILogon part, and won't work.