### PR TITLE
[DM-25730] Use cert from installer on test environments

### DIFF
--- a/services/nginx-ingress/values-gold-leader.yaml
+++ b/services/nginx-ingress/values-gold-leader.yaml
@@ -1,7 +1,7 @@
 nginx-ingress:
   controller:
     extraArgs:
-      default-ssl-certificate: cert-manager/default-certificate
+      default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
       use-forwarded-headers: "true"

--- a/services/nginx-ingress/values-red-five.yaml
+++ b/services/nginx-ingress/values-red-five.yaml
@@ -1,7 +1,7 @@
 nginx-ingress:
   controller:
     extraArgs:
-      default-ssl-certificate: cert-manager/default-certificate
+      default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
       use-forwarded-headers: "true"

--- a/services/nginx-ingress/values-rogue-two.yaml
+++ b/services/nginx-ingress/values-rogue-two.yaml
@@ -1,7 +1,7 @@
 nginx-ingress:
   controller:
     extraArgs:
-      default-ssl-certificate: cert-manager/default-certificate
+      default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
       use-forwarded-headers: "true"


### PR DESCRIPTION
Go back to the default tls cert since there are problems using
the cert manager bot.  That means we need to point the path here
back.