### PR TITLE
[DM-25708] Upgrade vault-secrets-operator

### DIFF
--- a/services/vault-secrets-operator/requirements.yaml
+++ b/services/vault-secrets-operator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: vault-secrets-operator
-  version: 1.4.0
+  version: 1.7.1
   repository: https://ricoberger.github.io/helm-charts/

--- a/services/vault-secrets-operator/values.yaml
+++ b/services/vault-secrets-operator/values.yaml
@@ -1,10 +1,14 @@
 vault-secrets-operator:
   environmentVars:
-    - envName: VAULT_TOKEN
-      secretName: vault-secrets-operator
-      secretKey: VAULT_TOKEN
-    - envName: VAULT_TOKEN_LEASE_DURATION
-      secretName: vault-secrets-operator
-      secretKey: VAULT_TOKEN_LEASE_DURATION
+    - name: VAULT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: vault-secrets-operator
+          key: VAULT_TOKEN
+    - name: VAULT_TOKEN_LEASE_DURATION
+      valueFrom:
+        secretKeyRef:
+          name: vault-secrets-operator
+          key: VAULT_TOKEN_LEASE_DURATION
   vault:
     address: "https://vault.lsst.codes"


### PR DESCRIPTION
Upgrade to the latest upstream Helm chart.  The syntax of the
environmentVars values.yaml override has changed to now match the
syntax used in deployments, so update accordingly.