### PR TITLE
[DM-23047] Set java heap size for TAP

### DIFF
--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -28,6 +28,8 @@ cadc-tap:
       cpu: 8.0
       memory: 16G
 
+  jvm_max_heap_size: 15G
+
   aux_resources:
     requests:
       cpu: 0.25

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -30,6 +30,8 @@ cadc-tap:
       cpu: 8.0
       memory: 16G
 
+  jvm_max_heap_size: 15G
+
   aux_resources:
     requests:
       cpu: 0.25


### PR DESCRIPTION
This will tell java to allow a larger heap size, which is independent
of the kubernetes limits.  Otherwise java will try to compute it by
itself and get confused.