### PR TITLE
[DM-25487] Fix syntax error in cert-manager secret template

### DIFF
--- a/services/cert-manager/templates/vault-secret.yaml
+++ b/services/cert-manager/templates/vault-secret.yaml
@@ -1,4 +1,4 @@
-{{- if Values.solver.route53 -}}
+{{- if .Values.solver.route53 -}}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:


### PR DESCRIPTION
.Values, not Values, when testing whether the DNS solver is
configured.