### PR TITLE
[DM-25487] Standardize nginx-ingress settings with NCSA

### DIFF
--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -4,6 +4,10 @@ nginx-ingress:
       default-ssl-certificate: cert-manager/default-certificate
     config:
       compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true

--- a/services/nginx-ingress/values-gold-leader.yaml
+++ b/services/nginx-ingress/values-gold-leader.yaml
@@ -4,6 +4,10 @@ nginx-ingress:
       default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true

--- a/services/nginx-ingress/values-nublado.yaml
+++ b/services/nginx-ingress/values-nublado.yaml
@@ -4,6 +4,10 @@ nginx-ingress:
       default-ssl-certificate: cert-manager/default-certificate
     config:
       compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true

--- a/services/nginx-ingress/values-red-five.yaml
+++ b/services/nginx-ingress/values-red-five.yaml
@@ -4,6 +4,10 @@ nginx-ingress:
       default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true

--- a/services/nginx-ingress/values-rogue-two.yaml
+++ b/services/nginx-ingress/values-rogue-two.yaml
@@ -4,6 +4,10 @@ nginx-ingress:
       default-ssl-certificate: default/tls-certificate
     config:
       compute-full-forwarded-for: "true"
+      large-client-header-buffers: "4 64k"
+      proxy-body-size: "100m"
+      proxy-buffer-size: "64k"
+      ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
       omitClusterIP: true


### PR DESCRIPTION
Copy the settings of large-client-header-buffers, proxy-body-size,
proxy-buffer-size, and ssl-redirect from NCSA (int) to the
enviroments where we manage the ingress so that the nublado ingress
consistently uses the same settings everywhere.