### PR TITLE
[DM-25487] Work around design flaws in Helm templating

### DIFF
--- a/services/cert-manager/templates/cluster-issuer.yaml
+++ b/services/cert-manager/templates/cluster-issuer.yaml
@@ -11,15 +11,21 @@ spec:
     privateKeySecretRef:
       name: cert-manager-letsencrypt
     solvers:
+      {{- if .Values.solver }}
       {{- if .Values.solver.route53 }}
       - dns01:
           cnameStrategy: Follow
           route53:
-            accessKeyID: {{ .Values.solver.route53.aws-access-key-id }}
-            hostedZoneID: {{ .Values.solver.route53.hosted-zone }}
+            accessKeyID: {{ .Values.solver.route53.aws_access_key_id }}
+            hostedZoneID: {{ .Values.solver.route53.hosted_zone }}
             secretAccessKeySecretRef:
               name: cert-manager-secret
               key: aws-secret-access-key
+      {{- else }}
+      - http01:
+          ingress:
+            class: nginx
+      {{- end -}}
       {{- else }}
       - http01:
           ingress:

--- a/services/cert-manager/templates/vault-secret.yaml
+++ b/services/cert-manager/templates/vault-secret.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.solver -}}
 {{- if .Values.solver.route53 -}}
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
   name: cert-manager-secret
 spec:
-  path: {{ .Values.solver.route53.vault-secret-path }}
+  path: {{ .Values.solver.route53.vault_secret_path }}
   type: Opaque
+{{- end -}}
 {{- end -}}

--- a/services/cert-manager/values-tucson-teststand.yaml
+++ b/services/cert-manager/values-tucson-teststand.yaml
@@ -1,8 +1,8 @@
 solver:
   route53:
-    aws-access-key-id: AKIAQSJOS2SFLUEVXZDB
-    hosted-zone: Z06873202D7WVTZUFOQ42
-    vault-secret-path: "secret/k8s_operator/tucson-teststand.lsst.codes/cert-manager"
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/tucson-teststand.lsst.codes/cert-manager"
 fqdn: tucson-teststand.lsst.codes
 cert-manager:
   installCRDs: true


### PR DESCRIPTION
Helm templates don't like dashes, so change the parameters for
cert-manager configuration to underscores.  Add another layer of
conditional because Helm can't understand that a boolean test on
a non-existent setting should be false and apparently doesn't have
short-circuiting "and" either.

This makes the cluster-issuer.yaml template temporarily messy by
repeating the else block.  I'm not bothering to fix this for now
because this will go away when we standardize on the DNS solver.