### PR TITLE
[DM-25487] Add region to DNS solver

### DIFF
--- a/services/cert-manager/templates/cluster-issuer.yaml
+++ b/services/cert-manager/templates/cluster-issuer.yaml
@@ -16,6 +16,7 @@ spec:
       - dns01:
           cnameStrategy: Follow
           route53:
+            region: us-east-1
             accessKeyID: {{ .Values.solver.route53.aws_access_key_id }}
             hostedZoneID: {{ .Values.solver.route53.hosted_zone }}
             secretAccessKeySecretRef:


### PR DESCRIPTION
No idea why this is required since Route 53 is regionless, but the
schema apparently requires it anyway.