### PR TITLE
[DM-25487] Switch to DNS solver for cert-manager

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -43,6 +43,13 @@ def generate_mobu_secrets():
       "Slack webhook for reporting mobu alerts.  Or use None for no alerting.")
   }
 
+def generate_cert_manager_secrets():
+  return {
+    "aws-secret-access-key": input_field("cert-manager",
+      "aws-secret-access-key",
+      "AWS secret access key for AKIAQSJOS2SFLUEVXZDB for DNS cert solver.")
+  }
+
 def generate_gafaelfawr_secrets():
   key = rsa.generate_private_key(
     backend=default_backend(),
@@ -70,6 +77,7 @@ def generate_secrets():
   secrets["nublado"] = generate_nublado_secrets(secrets["postgres"]["jupyterhub_password"])
   secrets["mobu"] = generate_mobu_secrets()
   secrets["gafaelfawr"] = generate_gafaelfawr_secrets()
+  secrets["cert-manager"] = generate_cert_manager_secrets()
   return secrets
 
 def generate_files(secrets):

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,10 +1,8 @@
 #!/bin/bash -ex
-USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN FULLCHAIN_CERT_FILE PRIVATE_KEY [REVISION]"
+USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN [REVISION]"
 ENVIRONMENT=${1:?$USAGE}
 VAULT_TOKEN=${2:?$USAGE}
-CERT_FILE=${3:?$USAGE}
-KEY_FILE=${4:?$USAGE}
-REVISION=${5:-HEAD}
+REVISION=${3:-HEAD}
 
 echo "Creating initial resources (like RBAC service account for tiller)..."
 kubectl apply -f initial-resources.yaml
@@ -28,13 +26,6 @@ kubectl create secret generic vault-secrets-operator \
   --namespace vault-secrets-operator \
   --from-literal=VAULT_TOKEN=$VAULT_TOKEN \
   --from-literal=VAULT_TOKEN_LEASE_DURATION=86400 \
-  --dry-run -o yaml | kubectl apply -f -
-
-echo "Creating TLS secret..."
-kubectl create secret tls tls-certificate \
-  --namespace default \
-  --cert $CERT_FILE \
-  --key $KEY_FILE \
   --dry-run -o yaml | kubectl apply -f -
 
 echo "Login to argocd..."

--- a/services/cert-manager/values-bleed.yaml
+++ b/services/cert-manager/values-bleed.yaml
@@ -1,3 +1,8 @@
+solver:
+  route53:
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/bleed.lsst.codes/cert-manager"
 fqdn: bleed.lsst.codes
 cert-manager:
   installCRDs: true

--- a/services/cert-manager/values-gold-leader.yaml
+++ b/services/cert-manager/values-gold-leader.yaml
@@ -1,3 +1,8 @@
+solver:
+  route53:
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/gold-leader.lsst.codes/cert-manager"
 fqdn: gold-leader.lsst.codes
 cert-manager:
   installCRDs: true

--- a/services/cert-manager/values-nublado.yaml
+++ b/services/cert-manager/values-nublado.yaml
@@ -1,3 +1,8 @@
+solver:
+  route53:
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/nublado.lsst.codes/cert-manager"
 fqdn: nublado.lsst.codes
 cert-manager:
   installCRDs: true

--- a/services/cert-manager/values-red-five.yaml
+++ b/services/cert-manager/values-red-five.yaml
@@ -1,3 +1,8 @@
+solver:
+  route53:
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/red-five.lsst.codes/cert-manager"
 fqdn: red-five.lsst.codes
 cert-manager:
   installCRDs: true

--- a/services/cert-manager/values-rogue-two.yaml
+++ b/services/cert-manager/values-rogue-two.yaml
@@ -1,3 +1,8 @@
+solver:
+  route53:
+    aws_access_key_id: AKIAQSJOS2SFLUEVXZDB
+    hosted_zone: Z06873202D7WVTZUFOQ42
+    vault_secret_path: "secret/k8s_operator/rogue-two.lsst.codes/cert-manager"
 fqdn: rogue-two.lsst.codes
 cert-manager:
   installCRDs: true


### PR DESCRIPTION
Change all remaining environments where we manage the ingress to
use the DNS solver for cert-manager.  This removes the need to
provide the wildcard certificate as input to install.sh, so remove
the handling there and instead add a prompt for the AWS secret key.