### PR TITLE
Set a weekly schedule for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "config:base"
+    "config:base", "schedule:weekly"
   ]
 }


### PR DESCRIPTION
We don't need to get the pull requests as soon as a new release
happens.  This aligns with Monday being the day that we merge
third-party dependency updates.