### PR TITLE
Revert "Update helm chart cert-manager to v0.16.0"

### DIFF
--- a/services/cert-manager/requirements.yaml
+++ b/services/cert-manager/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cert-manager
-  version: v0.16.0
+  version: v0.15.2
   repository: https://charts.jetstack.io


### PR DESCRIPTION
This reverts commit ec8bd0daf71473e8d0010a8efac699b462a0a593.
Applying this update hangs due to a bug in Kubernetes.