### PR TITLE
Revert Gafaelfawr back to 1.3.5

### DIFF
--- a/services/gafaelfawr/requirements.yaml
+++ b/services/gafaelfawr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: gafaelfawr
-    version: 1.3.6
+    version: 1.3.5
     repository: https://lsst-sqre.github.io/charts/

--- a/services/gafaelfawr/values-bleed.yaml
+++ b/services/gafaelfawr/values-bleed.yaml
@@ -1,8 +1,5 @@
 gafaelfawr:
   host: bleed.lsst.codes
-  image:
-    tag: "tickets-DM-26078"
-    pullPolicy: "Always"
   vault_secrets_path: "secret/k8s_operator/bleed.lsst.codes/gafaelfawr"
 
   # Do not specify ingress.host because we're using the wildcard virtual host.


### PR DESCRIPTION
Pause here until we're ready to release a new version of Gafaelfawr
and roll out Redis authentication everywhere.