### PR TITLE
[DM-26523] Set vault-secrets-operator lifetime to 1y

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -25,7 +25,7 @@ echo "Creating vault secret..."
 kubectl create secret generic vault-secrets-operator \
   --namespace vault-secrets-operator \
   --from-literal=VAULT_TOKEN=$VAULT_TOKEN \
-  --from-literal=VAULT_TOKEN_LEASE_DURATION=86400 \
+  --from-literal=VAULT_TOKEN_LEASE_DURATION=31536000 \
   --dry-run -o yaml | kubectl apply -f -
 
 echo "Login to argocd..."


### PR DESCRIPTION
Before it was at 24h, which would shorten the lifetime of the
read tokens.  Therefore these would expire if they were not
renewed within 24h.