### PR TITLE
[DM-25487] Fix TLS issuer configuration for nublado

### DIFF
--- a/services/nublado/values-base.yaml
+++ b/services/nublado/values-base.yaml
@@ -54,7 +54,7 @@ nublado:
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       host: base-lsp.lsst.codes
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: base-lsp.lsst.codes
 

--- a/services/nublado/values-bleed.yaml
+++ b/services/nublado/values-bleed.yaml
@@ -48,7 +48,7 @@ nublado:
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: bleed.lsst.codes
 

--- a/services/nublado/values-gold-leader.yaml
+++ b/services/nublado/values-gold-leader.yaml
@@ -48,7 +48,7 @@ nublado:
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: gold-leader.lsst.codes
 

--- a/services/nublado/values-nublado.yaml
+++ b/services/nublado/values-nublado.yaml
@@ -51,7 +51,7 @@ nublado:
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: nublado.lsst.codes
 

--- a/services/nublado/values-red-five.yaml
+++ b/services/nublado/values-red-five.yaml
@@ -48,7 +48,7 @@ nublado:
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: red-five.lsst.codes
 

--- a/services/nublado/values-rogue-two.yaml
+++ b/services/nublado/values-rogue-two.yaml
@@ -48,7 +48,7 @@ nublado:
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: rogue-two.lsst.codes
 

--- a/services/nublado/values-summit.yaml
+++ b/services/nublado/values-summit.yaml
@@ -54,7 +54,7 @@ nublado:
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       host: summit-lsp.lsst.codes
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: summit-lsp.lsst.codes
 

--- a/services/nublado/values-tucson-teststand.yaml
+++ b/services/nublado/values-tucson-teststand.yaml
@@ -55,7 +55,7 @@ nublado:
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
       host: tucson-teststand.lsst.codes
       tls:
-        issuer: cert-issuer-letsencrypt-dns
+        cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret
         tls_host: tucson-teststand.lsst.codes
 


### PR DESCRIPTION
The nublado chart uses proxy.ingress.tls.cluster_issuer, not
proxy.ingress.tls.issuer, since the configured name must be a
cluster issuer.