### PR TITLE
[DM-25487] Switch bleed.lsst.codes to named virtual hosts

### DIFF
--- a/services/landing-page/values-bleed.yaml
+++ b/services/landing-page/values-bleed.yaml
@@ -1,4 +1,5 @@
 landing-page:
   motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "bleed.lsst.codes"
   image:
     tag: "3.0.1"

--- a/services/mobu/values-bleed.yaml
+++ b/services/mobu/values-bleed.yaml
@@ -2,6 +2,7 @@ mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/bleed.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/bleed.lsst.codes/mobu"
   environment_url: "https://bleed.lsst.codes"
+  host: "bleed.lsst.codes"
 
   image:
     tag: master

--- a/services/obstap/values-bleed.yaml
+++ b/services/obstap/values-bleed.yaml
@@ -1,5 +1,6 @@
 cadc-tap-postgres:
   tag: "1.0"
+  host: "bleed.lsst.codes"
 
   secrets:
     enabled: false

--- a/services/portal/values-bleed.yaml
+++ b/services/portal/values-bleed.yaml
@@ -3,6 +3,7 @@ firefly:
     tag: "1.1.1"
 
   ingress:
+    host: "bleed.lsst.codes"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/tap/values-bleed.yaml
+++ b/services/tap/values-bleed.yaml
@@ -2,6 +2,8 @@ cadc-tap:
   tag: "1.0.10"
   use_mock_qserv: true
 
+  host: "bleed.lsst.codes"
+
   secrets:
     enabled: false
 


### PR DESCRIPTION
There appears to be no way to avoid using the default certificate
with nginx and also use the * virtual host with TLS certificates
because nginx can't find the appropriate certificate to use and
falls back on the self-signed one.  Convert all the bleed app
installs to naming the ingress host so that TLS works properly.