### PR TITLE
[DM-25487] Switch to named virtual hosts everywhere

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
-USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN [REVISION]"
+USAGE="Usage: ./install.sh ENVIRONMENT VAULT_TOKEN HOSTNAME [REVISION]"
 ENVIRONMENT=${1:?$USAGE}
 VAULT_TOKEN=${2:?$USAGE}
-REVISION=${3:-HEAD}
+HOSTNAME=${3:?$USAGE}
+REVISION=${4:-HEAD}
 
 echo "Creating initial resources (like RBAC service account for tiller)..."
 kubectl apply -f initial-resources.yaml
@@ -18,6 +19,7 @@ echo "Update / install argocd using helm..."
 helm upgrade \
   --install argocd argo/argo-cd \
   --values argo-cd-values.yaml \
+  --set server.ingress.hosts="{$HOSTNAME}" \
   --namespace argocd \
   --wait --timeout 900 \
   --version 2.6.1

--- a/services/gafaelfawr/values-gold-leader.yaml
+++ b/services/gafaelfawr/values-gold-leader.yaml
@@ -1,5 +1,7 @@
 gafaelfawr:
   host: gold-leader.lsst.codes
+  ingress:
+    host: gold-leader.lsst.codes
   vault_secrets_path: "secret/k8s_operator/gold-leader.lsst.codes/gafaelfawr"
 
   # Do not specify ingress.host because we're using the wildcard virtual host.

--- a/services/gafaelfawr/values-nublado.yaml
+++ b/services/gafaelfawr/values-nublado.yaml
@@ -1,5 +1,7 @@
 gafaelfawr:
   host: nublado.lsst.codes
+  ingress:
+    host: nublado.lsst.codes
   vault_secrets_path: "secret/k8s_operator/nublado.lsst.codes/gafaelfawr"
 
   # Do not specify ingress.host because we're using the wildcard virtual host.

--- a/services/gafaelfawr/values-red-five.yaml
+++ b/services/gafaelfawr/values-red-five.yaml
@@ -1,5 +1,7 @@
 gafaelfawr:
   host: red-five.lsst.codes
+  ingress:
+    host: red-five.lsst.codes
   vault_secrets_path: "secret/k8s_operator/red-five.lsst.codes/gafaelfawr"
 
   # Do not specify ingress.host because we're using the wildcard virtual host.

--- a/services/gafaelfawr/values-rogue-two.yaml
+++ b/services/gafaelfawr/values-rogue-two.yaml
@@ -1,5 +1,7 @@
 gafaelfawr:
   host: rogue-two.lsst.codes
+  ingress:
+    host: rogue-two.lsst.codes
   vault_secrets_path: "secret/k8s_operator/rogue-two.lsst.codes/gafaelfawr"
 
   # Do not specify ingress.host because we're using the wildcard virtual host.

--- a/services/landing-page/values-gold-leader.yaml
+++ b/services/landing-page/values-gold-leader.yaml
@@ -1,4 +1,5 @@
 landing-page:
   motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "gold-leader.lsst.codes"
   image:
     tag: "3.0.1"

--- a/services/landing-page/values-nublado.yaml
+++ b/services/landing-page/values-nublado.yaml
@@ -1,4 +1,5 @@
 landing-page:
   motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "nublado.lsst.codes"
   image:
     tag: "3.0.1"

--- a/services/landing-page/values-red-five.yaml
+++ b/services/landing-page/values-red-five.yaml
@@ -1,4 +1,5 @@
 landing-page:
   motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "red-five.lsst.codes"
   image:
     tag: "3.0.1"

--- a/services/landing-page/values-rogue-two.yaml
+++ b/services/landing-page/values-rogue-two.yaml
@@ -1,4 +1,5 @@
 landing-page:
   motd_url: https://raw.githubusercontent.com/lsst-dm/lsp-landing-page/master/motd/integration.md
+  host: "rogue-two.lsst.codes"
   image:
     tag: "3.0.1"

--- a/services/logging/values-red-five.yaml
+++ b/services/logging/values-red-five.yaml
@@ -50,8 +50,8 @@ opendistro-es:
         nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
         nginx.ingress.kubernetes.io/auth-signin: "https://red-five.lsst.codes/login"
         nginx.ingress.kubernetes.io/auth-url: "https://red-five.lsst.codes/auth?scope=exec:admin"
-      path:
-        - logs
+      hosts:
+        - "red-five.lsst.codes/logs"
 
 fluentd-elasticsearch:
   elasticsearch:

--- a/services/mobu/values-gold-leader.yaml
+++ b/services/mobu/values-gold-leader.yaml
@@ -2,6 +2,7 @@ mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/gold-leader.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/gold-leader.lsst.codes/mobu"
   environment_url: "https://gold-leader.lsst.codes"
+  host: "gold-leader.lsst.codes"
 
   image:
     tag: master

--- a/services/mobu/values-nublado.yaml
+++ b/services/mobu/values-nublado.yaml
@@ -2,6 +2,7 @@ mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/nublado.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/nublado.lsst.codes/mobu"
   environment_url: "https://nublado.lsst.codes"
+  host: "nublado.lsst.codes"
 
   image:
     tag: master

--- a/services/mobu/values-red-five.yaml
+++ b/services/mobu/values-red-five.yaml
@@ -2,6 +2,7 @@ mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/red-five.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/red-five.lsst.codes/mobu"
   environment_url: "https://red-five.lsst.codes"
+  host: "red-five.lsst.codes"
 
   image:
     tag: master

--- a/services/mobu/values-rogue-two.yaml
+++ b/services/mobu/values-rogue-two.yaml
@@ -2,6 +2,7 @@ mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/rogue-two.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/rogue-two.lsst.codes/mobu"
   environment_url: "https://rogue-two.lsst.codes"
+  host: "rogue-two.lsst.codes"
 
   image:
     tag: master

--- a/services/nublado/values-gold-leader.yaml
+++ b/services/nublado/values-gold-leader.yaml
@@ -47,6 +47,7 @@ nublado:
           auth_request_set $auth_token $upstream_http_x_auth_request_token;
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
+      host: gold-leader.lsst.codes
       tls:
         cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret

--- a/services/nublado/values-nublado.yaml
+++ b/services/nublado/values-nublado.yaml
@@ -50,6 +50,7 @@ nublado:
           auth_request_set $auth_token $upstream_http_x_auth_request_token;
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
+      host: nublado.lsst.codes
       tls:
         cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret

--- a/services/nublado/values-red-five.yaml
+++ b/services/nublado/values-red-five.yaml
@@ -47,6 +47,7 @@ nublado:
           auth_request_set $auth_token $upstream_http_x_auth_request_token;
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
+      host: red-five.lsst.codes
       tls:
         cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret

--- a/services/nublado/values-rogue-two.yaml
+++ b/services/nublado/values-rogue-two.yaml
@@ -47,6 +47,7 @@ nublado:
           auth_request_set $auth_token $upstream_http_x_auth_request_token;
           proxy_set_header X-Portal-Authorization "Bearer $auth_token";
           error_page 403 = "/auth/forbidden?scope=exec:notebook";
+      host: rogue-two.lsst.codes
       tls:
         cluster_issuer: cert-issuer-letsencrypt-dns
         secret: nublado-tls-secret

--- a/services/obstap/values-gold-leader.yaml
+++ b/services/obstap/values-gold-leader.yaml
@@ -1,5 +1,6 @@
 cadc-tap-postgres:
   tag: "1.0"
+  host: "gold-leader.lsst.codes"
 
   secrets:
     enabled: false

--- a/services/obstap/values-nublado.yaml
+++ b/services/obstap/values-nublado.yaml
@@ -1,5 +1,6 @@
 cadc-tap-postgres:
   tag: "1.0"
+  host: "nublado.lsst.codes"
 
   secrets:
     enabled: false

--- a/services/obstap/values-red-five.yaml
+++ b/services/obstap/values-red-five.yaml
@@ -1,5 +1,6 @@
 cadc-tap-postgres:
   tag: "1.0"
+  host: "red-five.lsst.codes"
 
   secrets:
     enabled: false

--- a/services/obstap/values-rogue-two.yaml
+++ b/services/obstap/values-rogue-two.yaml
@@ -1,5 +1,6 @@
 cadc-tap-postgres:
   tag: "1.0"
+  host: "rogue-two.lsst.codes"
 
   secrets:
     enabled: false

--- a/services/portal/values-gold-leader.yaml
+++ b/services/portal/values-gold-leader.yaml
@@ -3,6 +3,7 @@ firefly:
     tag: "1.1.1"
 
   ingress:
+    host: "gold-leader.lsst.codes"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/portal/values-nublado.yaml
+++ b/services/portal/values-nublado.yaml
@@ -3,6 +3,7 @@ firefly:
     tag: "1.1.1"
 
   ingress:
+    host: "nublado.lsst.codes"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/portal/values-red-five.yaml
+++ b/services/portal/values-red-five.yaml
@@ -3,6 +3,7 @@ firefly:
     tag: "1.1.1"
 
   ingress:
+    host: "red-five.lsst.codes"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/portal/values-rogue-two.yaml
+++ b/services/portal/values-rogue-two.yaml
@@ -3,6 +3,7 @@ firefly:
     tag: "1.1.1"
 
   ingress:
+    host: "rogue-two.lsst.codes"
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token

--- a/services/tap/values-gold-leader.yaml
+++ b/services/tap/values-gold-leader.yaml
@@ -2,6 +2,8 @@ cadc-tap:
   tag: "1.0.10"
   use_mock_qserv: true
 
+  host: "gold-leader.lsst.codes"
+
   secrets:
     enabled: false
 

--- a/services/tap/values-nublado.yaml
+++ b/services/tap/values-nublado.yaml
@@ -2,6 +2,8 @@ cadc-tap:
   tag: "1.0.10"
   use_mock_qserv: true
 
+  host: "nublado.lsst.codes"
+
   secrets:
     enabled: false
 

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -2,6 +2,8 @@ cadc-tap:
   tag: "1.0.10"
   use_mock_qserv: true
 
+  host: "red-five.lsst.codes"
+
   secrets:
     enabled: false
 

--- a/services/tap/values-rogue-two.yaml
+++ b/services/tap/values-rogue-two.yaml
@@ -2,6 +2,8 @@ cadc-tap:
   tag: "1.0.10"
   use_mock_qserv: true
 
+  host: "rogue-two.lsst.codes"
+
   secrets:
     enabled: false
 


### PR DESCRIPTION
Certificate management by configuring the TLS certificate for
nublado's JupyterHub proxy and letting everyone else inherit it
via TLS merging on a virtual host only works with named virtual
hosts because ingress-nginx won't merge TLS for the * virtual host.

Therefore, change all enviroments to named virtual hosts.

This was already the case for the NCSA, summit, base, and Tucson
test stand environments, so this change is only in the GKE
enviroments.  Also add a parameter to the install.sh installer
script for the hostname so that Argo CD can be configured with the
appropriate named virtual host as well.