### PR TITLE
[DM-25487] Move cert-issuer to a later sync wave

### DIFF
--- a/science-platform/templates/cert-issuer-application.yaml
+++ b/science-platform/templates/cert-issuer-application.yaml
@@ -12,6 +12,8 @@ kind: Application
 metadata:
   name: cert-issuer
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
It needs to sync after cert-manager.  The sync wave was set on the
individual resources, but not on the application.  See if setting it
on the application will help.