### PR TITLE
[DM-25487] Move cert-issuer to cert-manager namespace

### DIFF
--- a/science-platform/templates/cert-issuer-application.yaml
+++ b/science-platform/templates/cert-issuer-application.yaml
@@ -1,12 +1,4 @@
 {{- if .Values.cert_issuer.enabled -}}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-issuer
-spec:
-  finalizers:
-    - kubernetes
----
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -18,7 +10,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: cert-issuer
+    namespace: cert-manager
     server: https://kubernetes.default.svc
   project: default
   source:


### PR DESCRIPTION
The secret for a ClusterIssuer has to be in the cert-manager
namespace, so creating a separate cert-issuer namespace does not
work.