### PR TITLE
[DM-25487] Fix initial sync ordering

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -75,13 +75,13 @@ argocd app sync science-platform \
 echo "Syncing critical early applications"
 argocd app sync nginx-ingress \
   --port-forward \
-  --port-forward-namespace argocd
+  --port-forward-namespace argocd || true
 argocd app sync cert-manager \
   --port-forward \
-  --port-forward-namespace argocd
+  --port-forward-namespace argocd || true
 argocd app sync cert-issuer \
   --port-forward \
-  --port-forward-namespace argocd
+  --port-forward-namespace argocd || true
 
 echo "Sync remaining science platform apps"
 argocd app sync -l "argocd.argoproj.io/instance=science-platform" \

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -72,7 +72,18 @@ argocd app sync science-platform \
   --port-forward \
   --port-forward-namespace argocd
 
-echo "Sync science platform apps"
+echo "Syncing critical early applications"
+argocd app sync nginx-ingress \
+  --port-forward \
+  --port-forward-namespace argocd
+argocd app sync cert-manager \
+  --port-forward \
+  --port-forward-namespace argocd
+argocd app sync cert-issuer \
+  --port-forward \
+  --port-forward-namespace argocd
+
+echo "Sync remaining science platform apps"
 argocd app sync -l "argocd.argoproj.io/instance=science-platform" \
   --port-forward \
   --port-forward-namespace argocd

--- a/science-platform/templates/cert-issuer-application.yaml
+++ b/science-platform/templates/cert-issuer-application.yaml
@@ -4,8 +4,6 @@ kind: Application
 metadata:
   name: cert-issuer
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/services/cert-issuer/templates/cluster-issuer.yaml
+++ b/services/cert-issuer/templates/cluster-issuer.yaml
@@ -2,8 +2,6 @@ apiVersion: cert-manager.io/v1alpha3
 kind: ClusterIssuer
 metadata:
   name: cert-issuer-letsencrypt-dns
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory


### PR DESCRIPTION
When bootstrapping the cluster, sync nginx-ingress, cert-manager,
and cert-issuer first.  Drop all the sync wave annotations, which
appear to just confuse matters and cause the sync of the
science-platform app to hang.