### PR TITLE
[DM-25487] Document Route 53 setup for cert-issuer

### DIFF
--- a/docs/cert-issuer/index.rst
+++ b/docs/cert-issuer/index.rst
@@ -45,6 +45,8 @@ replacing ``<cluster-name>`` with the FQDN of the cluster, corresponding to the 
 See :doc:`../vault-secrets-operator/index` for more information.
 
 Then, in Route 53, create a CNAME from ``_acme-challenge.<cluster-name>`` to ``_acme-challenge.tls.lsst.codes``.
+The new Route 53 dialog box makes this very confusing to do in the console.
+Select **CNAME** from the lower drop-down menu and then **IP address or other value** from the top drop-down menu, and then you can enter ``_acme-challenge.tls.lsst.codes`` as the CNAME target.
 
 The access key ID in the configuration corresponds to the ``cert-manager-lsst-codes`` service user in AWS.
 The hosted zone is the ``tls.lsst.codes`` hosted zone, where all challenge responses will be created.

--- a/docs/cert-issuer/index.rst
+++ b/docs/cert-issuer/index.rst
@@ -44,9 +44,11 @@ To configure it, add the following to the ``values-*.yaml`` file for an environm
 replacing ``<cluster-name>`` with the FQDN of the cluster, corresponding to the root of the Vault secrets for that cluster.
 See :doc:`../vault-secrets-operator/index` for more information.
 
-This access key ID corresponds to the ``cert-manager-lsst-codes`` service user in AWS.
+Then, in Route 53, create a CNAME from ``_acme-challenge.<cluster-name>`` to ``_acme-challenge.tls.lsst.codes``.
+
+The access key ID in the configuration corresponds to the ``cert-manager-lsst-codes`` service user in AWS.
 The hosted zone is the ``tls.lsst.codes`` hosted zone, where all challenge responses will be created.
-To limit the scope of access in case of a compromise, this AWS service user does not have write access to the full ``lsst.codes`` domain.
+To limit the scope of access in case of a compromise, this AWS service user does not have write access to the full ``lsst.codes`` domain (hence the need for the CNAME).
 This AWS service user can be used for all Science Platform deployments in the ``lsst.codes`` domain.
 It is configured according to the `cert-manager documentation for Route 53 <https://cert-manager.io/docs/configuration/acme/dns01/route53/>`__.
 


### PR DESCRIPTION
Document the need to create a CNAME to tls.lsst.codes for any
new cluster.