### PR TITLE
[DM-25963] Add SQuaSH applications to lsp-deploy

### DIFF
--- a/science-platform/Chart.yaml
+++ b/science-platform/Chart.yaml
@@ -1,3 +1,3 @@
-apiVerison: v1
+apiVersion: v1
 name: science-platform
-verison: 1.0.0
+version: 1.0.0

--- a/science-platform/templates/chronograf-application.yaml
+++ b/science-platform/templates/chronograf-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.chronograf.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chronograf
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: chronograf
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: chronograf
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/chronograf
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.chronograf.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/templates/influxdb-application.yaml
+++ b/science-platform/templates/influxdb-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.influxdb.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: influxdb
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: influxdb
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: influxdb
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/influxdb
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.influxdb.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/templates/kapacitor-application.yaml
+++ b/science-platform/templates/kapacitor-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.kapacitor.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kapacitor
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kapacitor
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: kapacitor
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/kapacitor
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.kapacitor.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/templates/squash-api-application.yaml
+++ b/science-platform/templates/squash-api-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.squash_api.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: squash-api
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: squash-api
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: squash-api
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/squash-api
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.squash_api.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: false
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: false
 vault_secrets_operator:

--- a/science-platform/values-bleed.yaml
+++ b/science-platform/values-bleed.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: true
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-gold-leader.yaml
+++ b/science-platform/values-gold-leader.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: true
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: false
 cert_manager:
   enabled: false
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: false
 cert_manager:
   enabled: false
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: false
 vault_secrets_operator:

--- a/science-platform/values-nublado.yaml
+++ b/science-platform/values-nublado.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: true
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-rogue-two.yaml
+++ b/science-platform/values-rogue-two.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: true
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-squash-sandbox.yaml
+++ b/science-platform/values-squash-sandbox.yaml
@@ -1,4 +1,4 @@
-environment: red-five
+environment: squash-sandbox
 
 argo:
   enabled: true
@@ -7,32 +7,32 @@ cert_issuer:
 cert_manager:
   enabled: true
 chronograf:
-  enabled: false
+  enabled: true
 gafaelfawr:
   enabled: true
 influxdb:
-  enabled: false
-kapacitor:
-  enabled: false
-landing_page:
   enabled: true
+kapacitor:
+  enabled: true
+landing_page:
+  enabled: false
 logging:
   enabled: false
 mobu:
-  enabled: true
+  enabled: false
 nginx_ingress:
   enabled: true
 nublado:
-  enabled: true
-obstap:
-  enabled: true
-portal:
-  enabled: true
-postgres:
-  enabled: true
-squash_api:
   enabled: false
-tap:
+obstap:
+  enabled: false
+portal:
+  enabled: false
+postgres:
+  enabled: false
+squash_api:
   enabled: true
+tap:
+  enabled: false
 vault_secrets_operator:
   enabled: true

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: false
 cert_manager:
   enabled: false
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: true
 vault_secrets_operator:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: false
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: true
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: false
 vault_secrets_operator:

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -6,8 +6,14 @@ cert_issuer:
   enabled: true
 cert_manager:
   enabled: true
+chronograf:
+  enabled: false
 gafaelfawr:
   enabled: true
+influxdb:
+  enabled: false
+kapacitor:
+  enabled: false
 landing_page:
   enabled: true
 logging:
@@ -24,6 +30,8 @@ portal:
   enabled: false
 postgres:
   enabled: true
+squash_api:
+  enabled: false
 tap:
   enabled: false
 vault_secrets_operator:

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -9,7 +9,16 @@ cert_issuer:
 cert_manager:
   enabled: true
   revision: HEAD
+chronograf:
+  enabled: true
+  revision: HEAD
 gafaelfawr:
+  enabled: true
+  revision: HEAD
+influxdb:
+  enabled: true
+  revision: HEAD
+kapacitor:
   enabled: true
   revision: HEAD
 landing_page:
@@ -34,6 +43,9 @@ portal:
   enabled: true
   revision: HEAD
 postgres:
+  enabled: true
+  revision: HEAD
+squash_api:
   enabled: true
   revision: HEAD
 tap:

--- a/services/chronograf/Chart.yaml
+++ b/services/chronograf/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: chronograf
+version: 0.1.0

--- a/services/chronograf/requirements.yaml
+++ b/services/chronograf/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: chronograf
+  version: 1.1.17
+  repository: https://helm.influxdata.com/

--- a/services/chronograf/templates/chronograf-oauth.yaml
+++ b/services/chronograf/templates/chronograf-oauth.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: chronograf-oauth
+  namespace: chronograf
+spec:
+  path: {{ .Values.vaultSecretsPath }}
+  type: Opaque

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -72,6 +72,7 @@ chronograf:
   env:
     HOST_PAGE_DISABLED: true
     BASE_PATH: /chronograf
+    GENERIC_NAME: "CILogon"
     GENERIC_AUTH_URL: https://squash-sandbox.lsst.codes/auth/openid/login
     GENERIC_TOKEN_URL: https://squash-sandbox.lsst.codes/auth/openid/token
     USE_ID_TOKEN: 1

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -66,8 +66,7 @@ chronograf:
     hostname: squash-sandbox.lsst.codes
     annotations:
       kubernetes.io/ingress.class: "nginx"
-      # kubernetes.io/tls-acme: "true"
-    path: "/chronograf"
+    path: "/chronograf/"
 
   ## OAuth Settings for OAuth Providers
   ## More information -> https://github.com/influxdata/chronograf/blob/master/docs/auth.md
@@ -93,6 +92,7 @@ chronograf:
   ## Extra environment variables that will be passed onto deployment pods
   env:
     HOST_PAGE_DISABLED: true
+    BASE_PATH: /chronograf
 
   ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
   ## This can be useful for auth tokens, etc

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -61,8 +61,7 @@ chronograf:
   ##
   ingress:
     enabled: true
-    tls: true
-    secretName: tls-certs
+    tls: false
     hostname: squash-sandbox.lsst.codes
     annotations:
       kubernetes.io/ingress.class: "nginx"

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -68,32 +68,21 @@ chronograf:
       kubernetes.io/ingress.class: "nginx"
     path: "/chronograf/"
 
-  ## OAuth Settings for OAuth Providers
-  ## More information -> https://github.com/influxdata/chronograf/blob/master/docs/auth.md
-  ##
-  oauth:
-    # Need to set to true to use any of the oauth options
-    enabled: false
-    generic:
-      enabled: false
-      # client_id: CHANGE_ME
-      # client_secret: CHANGE_ME
-      api_key: ""
-      scopes: ""
-      # eg. http://chronograf.foobar.com
-      public_url: ""
-      auth_url: ""
-      token_url: ""
-      api_url: ""
-      # optional
-      # name: "generic"
-      # domains: ""
-
   ## Extra environment variables that will be passed onto deployment pods
   env:
     HOST_PAGE_DISABLED: true
     BASE_PATH: /chronograf
+    GENERIC_AUTH_URL: https://squash-sandbox.lsst.codes/auth/openid/login
+    GENERIC_TOKEN_URL: https://squash-sandbox.lsst.codes/auth/openid/token
+    USE_ID_TOKEN: 1
+    JWKS_URL: https://squash-sandbox.lsst.codes/.well-known/jwks.json
+    GENERIC_API_URL: https://squash-sandbox.lsst.codes/auth/userinfo
+    GENERIC_SCOPES: openid
+    PUBLIC_URL: https://squash-sandbox.lsst.codes
 
   ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
   ## This can be useful for auth tokens, etc
-  envFromSecret: ""
+  envFromSecret: "chronograf-oauth"
+
+## Vault path for the chronograf-oauth secret
+vaultSecretsPath: secret/k8s_operator/squash-sandbox/chronograf-oauth

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -1,0 +1,99 @@
+chronograf:
+  ## Image Settings
+  ##
+  image:
+    repository: "chronograf"
+    tag: 1.8.6
+    pullPolicy: IfNotPresent
+
+  ## Specify a service type
+  ## ClusterIP is default
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    replicas: 1
+    type: ClusterIP
+
+  ## Persist data to a persistent volume
+  ##
+  persistence:
+    enabled: true
+    ## chronograf data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 16Gi
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 0.1
+    limits:
+      memory: 2Gi
+      cpu: 2
+
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Affinity for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Configure the ingress object to hook into existing infastructure
+  ## ref : http://kubernetes.io/docs/user-guide/ingress/
+  ## OPTIONALLY you can set .Values.ingress.secretName to set which secret to use
+  ##
+  ingress:
+    enabled: true
+    tls: true
+    secretName: tls-certs
+    hostname: squash-sandbox.lsst.codes
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      # kubernetes.io/tls-acme: "true"
+    path: "/chronograf"
+
+  ## OAuth Settings for OAuth Providers
+  ## More information -> https://github.com/influxdata/chronograf/blob/master/docs/auth.md
+  ##
+  oauth:
+    # Need to set to true to use any of the oauth options
+    enabled: false
+    generic:
+      enabled: false
+      # client_id: CHANGE_ME
+      # client_secret: CHANGE_ME
+      api_key: ""
+      scopes: ""
+      # eg. http://chronograf.foobar.com
+      public_url: ""
+      auth_url: ""
+      token_url: ""
+      api_url: ""
+      # optional
+      # name: "generic"
+      # domains: ""
+
+  ## Extra environment variables that will be passed onto deployment pods
+  env:
+    HOST_PAGE_DISABLED: true
+
+  ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+  ## This can be useful for auth tokens, etc
+  envFromSecret: ""

--- a/services/chronograf/values-squash-sandbox.yaml
+++ b/services/chronograf/values-squash-sandbox.yaml
@@ -66,7 +66,7 @@ chronograf:
     hostname: squash-sandbox.lsst.codes
     annotations:
       kubernetes.io/ingress.class: "nginx"
-    path: "/chronograf/"
+    path: /chronograf(/|$)
 
   ## Extra environment variables that will be passed onto deployment pods
   env:

--- a/services/gafaelfawr/requirements.yaml
+++ b/services/gafaelfawr/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: gafaelfawr
-    version: 1.4.7
+    version: 1.5.0
     repository: https://lsst-sqre.github.io/charts/

--- a/services/gafaelfawr/values-squash-sandbox.yaml
+++ b/services/gafaelfawr/values-squash-sandbox.yaml
@@ -1,0 +1,21 @@
+gafaelfawr:
+  host: squash-sandbox.lsst.codes
+  ingress:
+    host: squash-sandbox.lsst.codes
+  vault_secrets_path: "secret/k8s_operator/squash-sandbox/gafaelfawr"
+
+  # Session length and token expiration (in minutes).
+  issuer:
+    exp_minutes: 43200  # 30 days
+
+  # Whether to support OpenID Connect clients.  If set to true,
+  # oidc-server-secrets must be set in the Gafaelfawr secret.
+  oidc_server:
+    enabled: true
+
+  # Use CILogon authentication.
+  cilogon:
+    client_id: "cilogon:/client_id/232eaabf026dab8b26f9c9770873cb7e"
+    redirect_url: "https://squash-sandbox.lsst.codes/login"
+    login_params:
+      skin: "LSST"

--- a/services/gafaelfawr/values-squash-sandbox.yaml
+++ b/services/gafaelfawr/values-squash-sandbox.yaml
@@ -8,6 +8,11 @@ gafaelfawr:
   issuer:
     exp_minutes: 43200  # 30 days
 
+    # Whether to issue tokens for InfluxDB.  If set to true, influxdb-secret
+    # must be set in the Gafaelfawr secret.
+    influxdb:
+      enabled: true
+
   # Whether to support OpenID Connect clients.  If set to true,
   # oidc-server-secrets must be set in the Gafaelfawr secret.
   oidc_server:

--- a/services/gafaelfawr/values-squash-sandbox.yaml
+++ b/services/gafaelfawr/values-squash-sandbox.yaml
@@ -12,6 +12,7 @@ gafaelfawr:
     # must be set in the Gafaelfawr secret.
     influxdb:
       enabled: true
+      username: "efdreader"
 
   # Whether to support OpenID Connect clients.  If set to true,
   # oidc-server-secrets must be set in the Gafaelfawr secret.

--- a/services/influxdb/Chart.yaml
+++ b/services/influxdb/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: influxdb
+version: 0.1.0

--- a/services/influxdb/requirements.yaml
+++ b/services/influxdb/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: influxdb
+  version: 4.8.4
+  repository: https://helm.influxdata.com/

--- a/services/influxdb/templates/influxdb-auth.yaml
+++ b/services/influxdb/templates/influxdb-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: influxdb-auth
+  namespace: influxdb
+spec:
+  path: {{ .Values.vaultSecretsPath }}
+  type: Opaque

--- a/services/influxdb/templates/influxdb-secret.yaml
+++ b/services/influxdb/templates/influxdb-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: ricoberger.de/v1alpha1
 kind: VaultSecret
 metadata:
-  name: influxdb-auth
+  name: influxdb-secret
   namespace: influxdb
 spec:
-  path: {{ .Values.vaultSecretsPath }}/influxdb-auth
+  path: {{ .Values.vaultSecretsPath }}/influxdb-secret
   type: Opaque

--- a/services/influxdb/values-squash-sandbox.yaml
+++ b/services/influxdb/values-squash-sandbox.yaml
@@ -171,6 +171,12 @@ influxdb:
   # - name: INFLUXDB_DB
   #   value: "demo"
 
+  ## The name of a secret in the same kubernetes namespace which contain values
+  ## to be added to the environment.
+  ## This can be used, for example, to set the INFLUXDB_HTTP_SHARED_SECRET
+  ## environment variable.
+  envFromSecret: influxdb-secret
+
   ## Change InfluxDB configuration parameters below:
   ## ref: https://docs.influxdata.com/influxdb/v1.8/administration/config/
   config:
@@ -247,5 +253,5 @@ influxdb:
     #   # endpointUrl: ""
 
 
-## Vault path for the influxdb-auth secret
-vaultSecretsPath: secret/k8s_operator/squash-sandbox/influxdb-auth
+## Vault path for the influxdb secrets
+vaultSecretsPath: secret/k8s_operator/squash-sandbox/

--- a/services/influxdb/values-squash-sandbox.yaml
+++ b/services/influxdb/values-squash-sandbox.yaml
@@ -182,8 +182,8 @@ influxdb:
   config:
     http:
       enabled: true
-      auth_enabled: true
-      max_row_limit: 0
+      auth-enabled: true
+      max-row-limit: 0
 
 
   # Allow executing custom init scripts

--- a/services/influxdb/values-squash-sandbox.yaml
+++ b/services/influxdb/values-squash-sandbox.yaml
@@ -135,8 +135,7 @@ influxdb:
 
   ingress:
     enabled: true
-    tls: true
-    secretName: tls-certs
+    tls: false
     hostname: squash-sandbox.lsst.codes
     annotations:
       kubernetes.io/ingress.class: "nginx"

--- a/services/influxdb/values-squash-sandbox.yaml
+++ b/services/influxdb/values-squash-sandbox.yaml
@@ -1,0 +1,250 @@
+influxdb:
+  ## influxdb image version
+  ## ref: https://hub.docker.com/r/library/influxdb/tags/
+  image:
+    repository: "influxdb"
+    tag: "1.8.2-alpine"
+    pullPolicy: IfNotPresent
+
+  ## Customize liveness, readiness and startup probes
+  ## ref: https://docs.influxdata.com/influxdb/v1.7/tools/api/#ping-http-endpoint
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ##
+  livenessProbe: {}
+  # initialDelaySeconds: 30
+  # timeoutSeconds: 5
+  # scheme: HTTP
+
+  readinessProbe: {}
+  # initialDelaySeconds: 5
+  # timeoutSeconds: 1
+  # scheme: HTTP
+
+  securityContext: {}
+  # runAsUser: 999
+  # runAsGroup: 999
+
+  startupProbe:
+    enabled: false
+    # failureThreshold: 6
+    # periodSeconds: 5
+    # scheme: HTTP
+
+
+  ## Specify a service type
+  ## NodePort is default
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    ## Add annotations to service
+    # annotations: {}
+    type: ClusterIP
+    ## Add IP Cluster
+    # clusterIP: ""
+    ## Add external IPs that route to one or more cluster nodes
+    # externalIPs: []
+    ## Specify LoadBalancer IP (only allow on some cloud provider)
+    # loadBalancerIP: ""
+    ## Allow source IPs to access on service (if empty, any access allow)
+    # loadBalancerSourceRanges: []
+
+  ## Persist data to a persistent volume
+  ##
+  persistence:
+    enabled: true
+    ## If true will use an existing PVC instead of creating one
+    # useExisting: false
+    ## Name of existing PVC to be used in the influx deployment
+    # name:
+    ## influxdb data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 100Gi
+
+  ## Create default user through Kubernetes job
+  ## Defaults indicated below
+  ##
+  setDefaultUser:
+    enabled: true
+
+    ## Image of the container used for job
+    ## Default: appropriate/curl:latest
+    ##
+    image: appropriate/curl:latest
+
+    ## Deadline for job so it does not retry forever.
+    ## Default: activeDeadline: 300
+    ##
+    activeDeadline: 300
+
+
+    ## Specify the number of retries before considering job as failed.
+    ## https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#pod-backoff-failure-policy
+    ##
+    backoffLimit: 6
+
+    ## Hook delete policy for helm.
+    ## Default: hookDeletePolicy: hook-succeeded
+    ##
+    hookDeletePolicy: hook-succeeded
+
+    ## Restart policy for job
+    ## Default: OnFailure
+    restartPolicy: OnFailure
+
+    user:
+      ## The user name
+      ## Default: "admin"
+      # username:
+
+      ## User password
+      ## single quotes must be escaped (\')
+      ## Default: (Randomly generated 10 characters of AlphaNum)
+      # password:
+
+      ## The user name and password are obtained from an existing secret. The expected
+      ## keys are `influxdb-user` and `influxdb-password`.
+      ## If set, the username and password values above are ignored.
+      existingSecret: influxdb-auth
+
+      ## User privileges
+      ## Default: "WITH ALL PRIVILEGES"
+      privileges: "WITH ALL PRIVILEGES"
+
+  ## Configure resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}
+  #  requests:
+  #    memory: 256Mi
+  #    cpu: 0.1
+  #  limits:
+  #    memory: 16Gi
+  #    cpu: 8
+
+  # Annotations to be added to InfluxDB pods
+  podAnnotations: {}
+
+  # Labels to be added to InfluxDB pods
+  podLabels: {}
+
+  ingress:
+    enabled: true
+    tls: true
+    secretName: tls-certs
+    hostname: squash-sandbox.lsst.codes
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+    path: "/influxdb"
+
+
+  ## Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
+  ## Affinity for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Tolerations for pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  # - key: "key"
+  #   operator: "Equal|Exists"
+  #   value: "value"
+  #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## The InfluxDB image uses several environment variables to automatically
+  ## configure certain parts of the server.
+  ## Ref: https://hub.docker.com/_/influxdb/
+  env: {}
+  # - name: INFLUXDB_DB
+  #   value: "demo"
+
+  ## Change InfluxDB configuration parameters below:
+  ## ref: https://docs.influxdata.com/influxdb/v1.8/administration/config/
+  config:
+    http:
+      enabled: true
+      auth_enabled: true
+      max_row_limit: 0
+
+
+  # Allow executing custom init scripts
+  #
+  # If the container finds any files with the extensions .sh or .iql inside of the
+  # /docker-entrypoint-initdb.d folder, it will execute them. The order they are
+  # executed in is determined by the shell. This is usually alphabetical order.
+  initScripts:
+    enabled: false
+    scripts:
+      init.iql: |+
+        CREATE DATABASE "telegraf" WITH DURATION 30d REPLICATION 1 NAME "rp_30d"
+
+  backup:
+    enabled: false
+    ## By default emptyDir is used as a transitory volume before uploading to object store.
+    ## As such, ensure that a sufficient ephemeral storage request is set to prevent node disk filling completely.
+    resources:
+      requests:
+        # memory: 512Mi
+        # cpu: 2
+        ephemeral-storage: "8Gi"
+    # limits:
+    #   memory: 1Gi
+    #   cpu: 4
+    #   ephemeral-storage: "16Gi"
+    ## If backup destination is PVC, or want to use intermediate PVC before uploading to object store.
+    persistence:
+      enabled: false
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      # storageClass: "-"
+      annotations:
+      accessMode: ReadWriteOnce
+      size: 8Gi
+    schedule: "0 0 * * *"
+    annotations: {}
+    podAnnotations: {}
+
+    ## Google Cloud Storage
+    # gcs:
+    #    serviceAccountSecret: influxdb-backup-key
+    #    serviceAccountSecretKey: key.json
+    #    destination: gs://bucket/influxdb
+
+    ## Azure
+    ## Secret is expected to have connection string stored in `connection-string` field
+    ## Existing container will be used or private one withing storage account will be created.
+    # azure:
+    #   storageAccountSecret: influxdb-backup-azure-key
+    #   destination_container: influxdb-container
+    #   destination_path: ""
+
+    ## Amazon S3 or compatible
+    ## Secret is expected to have AWS (or compatible) credentials stored in `credentials` field.
+    ## Please look at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
+    ## for the credentials format.
+    ## The bucket should already exist.
+    # s3:
+    #   credentialsSecret: aws-credentials-secret
+    #   destination: s3://bucket/path
+    #   ## Optional. Specify if you're using an alternate S3 endpoint.
+    #   # endpointUrl: ""
+
+
+## Vault path for the influxdb-auth secret
+vaultSecretsPath: secret/k8s_operator/squash-sandbox/influxdb-auth

--- a/services/influxdb/values-squash-sandbox.yaml
+++ b/services/influxdb/values-squash-sandbox.yaml
@@ -141,7 +141,8 @@ influxdb:
     annotations:
       kubernetes.io/ingress.class: "nginx"
       cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
-    path: "/influxdb"
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    path: /influxdb(/|$)(.*)
 
 
   ## Node labels for pod assignment

--- a/services/kapacitor/Chart.yaml
+++ b/services/kapacitor/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: kapacitor
+version: 0.1.0

--- a/services/kapacitor/requirements.yaml
+++ b/services/kapacitor/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: kapacitor
+  version: 1.3.1
+  repository: https://helm.influxdata.com/

--- a/services/kapacitor/templates/influxdb-auth.yaml
+++ b/services/kapacitor/templates/influxdb-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: influxdb-auth
+  namespace: kapacitor
+spec:
+  path: {{ .Values.vaultSecretsPath }}
+  type: Opaque

--- a/services/kapacitor/values-squash-sandbox.yaml
+++ b/services/kapacitor/values-squash-sandbox.yaml
@@ -1,0 +1,73 @@
+kapacitor:
+  ## influxdb image version
+  ## ref: https://hub.docker.com/r/library/influxdb/tags/
+  ##
+  image:
+    repository: "kapacitor"
+    tag: "1.5.6-alpine"
+    pullPolicy: IfNotPresent
+
+  ## Specify a service type, defaults to NodePort
+  ## ref: http://kubernetes.io/docs/user-guide/services/
+  ##
+  service:
+    type: ClusterIP
+
+  ## Persist data to a persistent volume
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## kapacitor data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 8Gi
+    # existingClaim: ""
+
+  resources:
+  requests:
+    memory: 256Mi
+    cpu: 0.1
+  limits:
+    memory: 2Gi
+    cpu: 2
+
+  ## Set the environment variables for kapacitor (or anything else you want to use)
+  ## ref: https://hub.docker.com/_/kapacitor/
+  ##
+  # Examples below
+  #
+  # envVars:
+  #   KAPACITOR_SLACK_ENABLED: true
+  #   KAPACITOR_SLACK_URL: "http://slack.com/xxxxx/xxxxx/xxxx/xxxxxxx"
+
+  ## Set the URL of InfluxDB instance to create subscription on
+  ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
+  ##
+  influxURL: http://influxdb.influxdb:8086
+
+  ## Name of an existing Secrect used to set the environment variables for the
+  ## InfluxDB user and password. The expected keys in the secret are
+  ## `influxdb-user` and `influxdb-password`.
+  ##
+  existingSecret: influxdb-auth
+
+  ## Role based access control
+  rbac:
+    create: true
+    namespaced: false
+
+  ## Service account
+  serviceAccount:
+    annotations: {}
+    create: true
+    name:
+
+## Vault path for the influxdb-auth secret
+vaultSecretsPath: secret/k8s_operator/squash-sandbox/influxdb-auth

--- a/services/squash-api/Chart.yaml
+++ b/services/squash-api/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: squash-api
+version: 0.1.0

--- a/services/squash-api/requirements.yaml
+++ b/services/squash-api/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: squash-api
+  version: 0.1.0
+  repository: https://lsst-sqre.github.io/charts/

--- a/services/squash-api/templates/vault-secrets.yaml
+++ b/services/squash-api/templates/vault-secrets.yaml
@@ -1,0 +1,44 @@
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: cloudsql-instance-credentials
+  namespace: squash-api
+spec:
+  path: {{ .Values.vaultSecretsBasePath }}/cloudsql-instance-credentials
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: squash-aws-credentials
+  namespace: squash-api
+spec:
+  path: {{ .Values.vaultSecretsBasePath }}/squash-aws-credentials
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: squash-credentials
+  namespace: squash-api
+spec:
+  path: {{ .Values.vaultSecretsBasePath }}/squash-credentials
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: squash-db-credentials
+  namespace: squash-api
+spec:
+  path: {{ .Values.vaultSecretsBasePath }}/squash-db-credentials
+  type: Opaque
+---
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: influxdb-auth
+  namespace: squash-api
+spec:
+  path: {{ .Values.vaultSecretsBasePath }}/influxdb-auth
+  type: Opaque

--- a/services/squash-api/values-squash-sandbox.yaml
+++ b/services/squash-api/values-squash-sandbox.yaml
@@ -68,10 +68,12 @@ squash-api:
   ingress:
     enabled: true
     annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/rewrite-target: /
       cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
     hosts:
     - host: squash-sandbox.lsst.codes
-      paths: ["/"]
+      paths: ["/squash-api"]
     tls:
     - secretName: "tls-certs"
       hosts:

--- a/services/squash-api/values-squash-sandbox.yaml
+++ b/services/squash-api/values-squash-sandbox.yaml
@@ -1,0 +1,89 @@
+squash-api:
+  replicaCount: 1
+
+  image:
+    repository: lsstsqre/squash-restful-api
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  cloudSQLImage:
+    repository: gcr.io/cloudsql-docker/gce-proxy
+    tag: "1.17"
+    pullPolicy: IfNotPresent
+
+  redisImage:
+    repository: redis
+    tag: "6.0"
+    pullPolicy: IfNotPresent
+
+  # SQuaSH Cloud SQL instance connection name
+  instanceConnectionName: "squash-db-sandbox"
+
+  # Credentials for the SQuaSH Cloud SQL service account
+  cloudSQLInstanceSecret: "cloudsql-instance-credentials"
+
+  # SQuaSH DB credentials
+  squashDBSecret: "squash-db-credentials"
+
+  # Default SQuaSH API credentials
+  squashSecret: "squash-credentials"
+
+  # If "True", job datetime is obtained from the job metadata instead of using
+  # current time. Use this option to restore existing jobs to SQuaSH.
+  squashETLMode: ""
+
+  # S3 Bucket to upload verification jobs
+  s3BucketName: "squash-sandbox"
+
+  # AWS credentials
+  awsSecret: "squash-aws-credentials"
+
+  # InfluxDB URL
+  influxUrl: "http://influxdb.influxdb:8086"
+  influxDb: "squash-sandbox"
+
+  # InfluxDB credentials
+  influxSecret: "influxdb-auth"
+
+  # Redis URL
+  redisUrl: "redis://squash-sandbox-squash-api-redis.squash-sandbox:6379"
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
+    hosts:
+    - host: squash-sandbox.lsst.codes
+      paths: ["/"]
+    tls:
+    - secretName: "tls-certs"
+      hosts:
+      - squash-sandbox.lsst.codes
+
+  resources: {}
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+## Base path for squash-api secrets in Vault
+vaultSecretsBasePath: secret/k8s_operator/squash-sandbox

--- a/services/squash-api/values-squash-sandbox.yaml
+++ b/services/squash-api/values-squash-sandbox.yaml
@@ -1,11 +1,6 @@
 squash-api:
   replicaCount: 1
 
-  image:
-    repository: lsstsqre/squash-restful-api
-    tag: latest
-    pullPolicy: IfNotPresent
-
   cloudSQLImage:
     repository: gcr.io/cloudsql-docker/gce-proxy
     tag: "1.17"


### PR DESCRIPTION
This PR adds the "squash-sandbox" environment to lsp-deploy enabling the following apps under the science-platform parent app

- nginx-ingress
- cert-issuer
- cert-manager
- vault-secrets-operator
- gafaelfawr
- squash-api
- chronograf
- influxdb
- kapacitor 

we took the opportunity to test the Chronograf, InfluxDB and Kapacitor Helm charts maintained by InfluxData and configure ingress rules to use a path base routing (`/squash-api`, `/chronograf` and `/influxdb`). We enable Gafaelfawr to authenticate Chronograf and to issue tokens for InfluxDB.
 
We tested that by deploying the above apps using Argo CD and this branch. Chronograf can be reached for example at https://squash-sandbox.lsst.codes/chronograf