### PR TITLE
[DM-25487] Add vault-secrets-operator to science-platform

### DIFF
--- a/science-platform/templates/vault-secrets-operator-application.yaml
+++ b/science-platform/templates/vault-secrets-operator-application.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.vault_secrets_operator.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault-secrets-operator
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault-secrets-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: vault-secrets-operator
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/vault-secrets-operator
+    repoURL: https://github.com/lsst-sqre/lsp-deploy.git
+    targetRevision: {{ .Values.vault_secrets_operator.revision }}
+{{- end -}}

--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: false
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-bleed.yaml
+++ b/science-platform/values-bleed.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-gold-leader.yaml
+++ b/science-platform/values-gold-leader.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-int.yaml
+++ b/science-platform/values-int.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: false
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-nublado.yaml
+++ b/science-platform/values-nublado.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-red-five.yaml
+++ b/science-platform/values-red-five.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-rogue-two.yaml
+++ b/science-platform/values-rogue-two.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-stable.yaml
+++ b/science-platform/values-stable.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: true
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -10,6 +10,10 @@ gafaelfawr:
   enabled: true
 landing_page:
   enabled: true
+logging:
+  enabled: false
+mobu:
+  enabled: false
 nginx_ingress:
   enabled: true
 nublado:
@@ -22,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: false
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values-tucson-teststand.yaml
+++ b/science-platform/values-tucson-teststand.yaml
@@ -26,3 +26,5 @@ postgres:
   enabled: true
 tap:
   enabled: false
+vault_secrets_operator:
+  enabled: true

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -39,3 +39,6 @@ postgres:
 tap:
   enabled: true
   revision: HEAD
+vault_secrets_operator:
+  enabled: true
+  revision: HEAD


### PR DESCRIPTION
The installer script syncs this app separately, but add it to the
app of apps anyway so that we stick with the pattern that
science-platform owns all of the apps.

Add some missing app configuration for the summit science-platform
definition.