### PR TITLE
Drop namespace for vault-secrets-operator

### DIFF
--- a/science-platform/templates/vault-secrets-operator-application.yaml
+++ b/science-platform/templates/vault-secrets-operator-application.yaml
@@ -1,12 +1,4 @@
 {{- if .Values.vault_secrets_operator.enabled -}}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: vault-secrets-operator
-spec:
-  finalizers:
-    - kubernetes
----
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
vault-secrets-operator has to be deployable as its own application
for early bootstrapping, so it creates its own namespace.  This then
duplicates the namespace created by science-platform for it.

Drop the latter, since it shouldn't be necessary (Argo CD will sync
the namespace first when syncing vault-secrets-operator).