### PR TITLE
[DM-27279] Move stable over to small qserv

### DIFF
--- a/services/tap/values-bleed.yaml
+++ b/services/tap/values-bleed.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "bleed.lsst.codes"

--- a/services/tap/values-gke.yaml
+++ b/services/tap/values-gke.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   secrets:

--- a/services/tap/values-gold-leader.yaml
+++ b/services/tap/values-gold-leader.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "gold-leader.lsst.codes"

--- a/services/tap/values-int.yaml
+++ b/services/tap/values-int.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: false
   qserv_host: "lsst-qserv-master03:4040"
 

--- a/services/tap/values-minikube.yaml
+++ b/services/tap/values-minikube.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "minikube.lsst.codes"

--- a/services/tap/values-nublado.yaml
+++ b/services/tap/values-nublado.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "nublado.lsst.codes"

--- a/services/tap/values-red-five.yaml
+++ b/services/tap/values-red-five.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "red-five.lsst.codes"

--- a/services/tap/values-rogue-two.yaml
+++ b/services/tap/values-rogue-two.yaml
@@ -1,5 +1,5 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: true
 
   host: "rogue-two.lsst.codes"

--- a/services/tap/values-stable.yaml
+++ b/services/tap/values-stable.yaml
@@ -1,7 +1,7 @@
 cadc-tap:
-  tag: "1.0.13"
+  tag: "1.0.14"
   use_mock_qserv: false
-  qserv_host: "qserv-master01:4040"
+  qserv_host: "lsst-qserv-master03:4040"
 
   querymonkey_replicas: 1
 


### PR DESCRIPTION
First, point stable over to the address of the small qserv.
Next, we need to release a new version of the TAP service to roll
out the proper monkey queries as well.  While we don't theoretically
need to roll this out everywhere (since only stable is running
the monkey) I like to keep the spirit of everything up to date.