### PR TITLE
[DM-27278] Add JupyterHub label to nginx pod on bleed

### DIFF
--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -16,6 +16,8 @@ nginx-ingress:
     metrics:
       service:
         omitClusterIP: true
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
   defaultBackend:
     service:
       omitClusterIP: true


### PR DESCRIPTION
This allows the nginx ingress to talk to the JupyterHub proxy via
its NetworkPolicy.  We will eventually need this configuration
everywhere, but start only on bleed for now.