### PR TITLE
[DM-27353] Helper scripts for minikube

### DIFF
--- a/installer/minikube/coredns.yaml
+++ b/installer/minikube/coredns.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+           lameduck 5s
+        }
+        rewrite name minikube.lsst.codes nginx-ingress-controller.nginx-ingress.svc.cluster.local
+        ready
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           fallthrough in-addr.arpa ip6.arpa
+           ttl 30
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf {
+           max_concurrent 1000
+        }
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/installer/minikube/setup_minikube.sh
+++ b/installer/minikube/setup_minikube.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -xe
+
+minikube start --driver=virtualbox --cpus=8 --memory=16g --disk-size=100g
+
+# This allows us to point minikube.lsst.codes to the nginx-ingress controller.
+# This is needed to allow for services inside the cluster to contact each
+# other using the public name minikube.lsst.codes
+kubectl apply -f coredns.yaml
+
+# Restart coredns
+kubectl scale deployment coredns --replicas=0 -n kube-system
+kubectl scale deployment coredns --replicas=1 -n kube-system


### PR DESCRIPTION
Making some helper scripts including one to make the cluster and
set up the appropriate coredns configmap to allow for DNS resolution
of minikube.lsst.codes to work from inside the cluster.

This should be run before the installer script.