### PR TITLE
Don't default the science-platform part to an environment name

### DIFF
--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -1,5 +1,3 @@
-environment: gke
-
 argo:
   enabled: true
   revision: HEAD


### PR DESCRIPTION
This might be confusing, as Adam will likely attest to.