### PR TITLE
[DM-26507] Fix configuration for argo-cd

### DIFF
--- a/services/argo-cd/values.yaml
+++ b/services/argo-cd/values.yaml
@@ -1,22 +1,25 @@
-redis:
-  enabled: true
+argo-cd:
+  fullnameOverride: argocd
 
-server:
-  ingress:
+  redis:
     enabled: true
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
-    paths:
-      - /argo-cd(/|$)(.*)
 
-  extraArgs:
-    - "--basehref=/argo-cd"
-    - "--insecure=true"
+  server:
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+      paths:
+        - /argo-cd(/|$)(.*)
 
-  config:
-    helm.repositories: |
-      - url: https://lsst-sqre.github.io/charts/
-        name: lsst-sqre
-      - url: https://ricoberger.github.io/helm-charts/
-        name: ricoberger
+    extraArgs:
+      - "--basehref=/argo-cd"
+      - "--insecure=true"
+
+    config:
+      helm.repositories: |
+        - url: https://lsst-sqre.github.io/charts/
+          name: lsst-sqre
+        - url: https://ricoberger.github.io/helm-charts/
+          name: ricoberger


### PR DESCRIPTION
Add the necessary extra level in values.yaml and override the
release name to preserve the naming when Argo CD was manually
installed with Helm.