### PR TITLE
[DM-27636] Fix nginx-ingress chart dependency

### DIFF
--- a/installer/argo-cd-values.yaml
+++ b/installer/argo-cd-values.yaml
@@ -20,3 +20,5 @@ server:
         name: lsst-sqre
       - url: https://ricoberger.github.io/helm-charts/
         name: ricoberger
+      - url: https://kubernetes.github.io/ingress-nginx/
+        name: ingress-nginx

--- a/services/argocd/values-base.yaml
+++ b/services/argocd/values-base.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-bleed.yaml
+++ b/services/argocd/values-bleed.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-gold-leader.yaml
+++ b/services/argocd/values-gold-leader.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-int.yaml
+++ b/services/argocd/values-int.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-minikube.yaml
+++ b/services/argocd/values-minikube.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-nts.yaml
+++ b/services/argocd/values-nts.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-nublado.yaml
+++ b/services/argocd/values-nublado.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-red-five.yaml
+++ b/services/argocd/values-red-five.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-rogue-two.yaml
+++ b/services/argocd/values-rogue-two.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-squash-sandbox.yaml
+++ b/services/argocd/values-squash-sandbox.yaml
@@ -21,3 +21,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-stable.yaml
+++ b/services/argocd/values-stable.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-summit.yaml
+++ b/services/argocd/values-summit.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/argocd/values-tucson-teststand.yaml
+++ b/services/argocd/values-tucson-teststand.yaml
@@ -23,3 +23,5 @@ argo-cd:
           name: lsst-sqre
         - url: https://ricoberger.github.io/helm-charts/
           name: ricoberger
+        - url: https://kubernetes.github.io/ingress-nginx/
+          name: ingress-nginx

--- a/services/nginx-ingress/requirements.yaml
+++ b/services/nginx-ingress/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
-- name: nginx-ingress
-  version: 1.41.3
-  repository: https://kubernetes-charts.storage.googleapis.com
+- name: ingress-nginx
+  version: 3.10.1
+  repository: https://kubernetes.github.io/ingress-nginx

--- a/services/nginx-ingress/values-bleed.yaml
+++ b/services/nginx-ingress/values-bleed.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-gold-leader.yaml
+++ b/services/nginx-ingress/values-gold-leader.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-minikube.yaml
+++ b/services/nginx-ingress/values-minikube.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-nublado.yaml
+++ b/services/nginx-ingress/values-nublado.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-red-five.yaml
+++ b/services/nginx-ingress/values-red-five.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-rogue-two.yaml
+++ b/services/nginx-ingress/values-rogue-two.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"

--- a/services/nginx-ingress/values-tucson-teststand.yaml
+++ b/services/nginx-ingress/values-tucson-teststand.yaml
@@ -1,4 +1,4 @@
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       compute-full-forwarded-for: "true"


### PR DESCRIPTION
Okay so the previous chart was marked as deprecated and moved to
a new helm chart repo.  So first we update the requirements.yaml
to point to that repository, and the new URL.  The version numbers
have also changed, so pick the latest one there that is published.

Now since the name of the chart has changed from nginx-ingress to
ingress-nginx, this means that the name in the requirements.yaml
changes as well.  And since this is used as the section in the
values files, all of those have to change to match that name.
Otherwise that configuration section will be ignored (which is
all of it).