### PR TITLE
[DM-27636] Fix minikube ingress

### DIFF
--- a/services/nginx-ingress/values-minikube.yaml
+++ b/services/nginx-ingress/values-minikube.yaml
@@ -8,16 +8,7 @@ ingress-nginx:
       ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
-      omitClusterIP: true
       externalTrafficPolicy: Local
+      type: NodePort
       nodePorts:
         https: 31337
-    stats:
-      service:
-        omitClusterIP: true
-    metrics:
-      service:
-        omitClusterIP: true
-  defaultBackend:
-    service:
-      omitClusterIP: true


### PR DESCRIPTION
Get rid of some parts that aren't used by the new chart, and
fix the nodeport which used to work with the old chart, but
hangs with the current settings.