### PR TITLE
Convert nginx-ingress chart to Helm v3 syntax

### DIFF
--- a/services/nginx-ingress/Chart.yaml
+++ b/services/nginx-ingress/Chart.yaml
@@ -1,3 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: nginx-ingress
 version: 1.0.0
+dependencies:
+- name: ingress-nginx
+  version: 3.12.0
+  repository: https://kubernetes.github.io/ingress-nginx

--- a/services/nginx-ingress/requirements.yaml
+++ b/services/nginx-ingress/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: ingress-nginx
-  version: 3.12.0
-  repository: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
The upstream chart now only supports Helm v3, so change our chart
to use Helm v3 syntax so that Argo CD will apply it with Helm v3.