### PR TITLE
Bump vault-secrets-operator to 1.10.1

### DIFF
--- a/services/vault-secrets-operator/requirements.yaml
+++ b/services/vault-secrets-operator/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: vault-secrets-operator
-  version: 1.10.0
+  version: 1.10.1
   repository: https://ricoberger.github.io/helm-charts/


### PR DESCRIPTION
Fixes ownership of secrets for Argo CD.