### PR TITLE
Fix exposurelog values for the NTS environment

### DIFF
--- a/services/exposurelog/values-nts.yaml
+++ b/services/exposurelog/values-nts.yaml
@@ -1,8 +1,10 @@
 exposurelog:
 
-  hostpath_1: /lsstdata/offline/teststand
+  nfs_path_1: /offline/teststand
 
-  butler_uri_1: /volume_1/NCSA_comcam
+  nfs_server: lsst-nfs.ncsa.illinois.edu
+
+  butler_uri_1: /volume_1/NCSA_comcam/gen3repo
 
   ingress:
     enabled: true


### PR DESCRIPTION
- Set correct values for nfs_path_1, butler_uri_1 and nfs_server at NCSA Test Stand