### PR TITLE
Revert cert-manager version

### DIFF
--- a/services/cert-manager/requirements.yaml
+++ b/services/cert-manager/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cert-manager
-  version: v1.1.0
+  version: v0.15.2
   repository: https://charts.jetstack.io


### PR DESCRIPTION
The new version doesn't seem to work correctly with Route 53.