### PR TITLE
Set values file when installing vault-secrets-operator

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -51,7 +51,8 @@ argocd app create vault-secrets-operator \
   --dest-server https://kubernetes.default.svc \
   --upsert \
   --port-forward \
-  --port-forward-namespace argocd
+  --port-forward-namespace argocd \
+  --values values-$ENVIRONMENT.yaml
 
 argocd app sync vault-secrets-operator \
   --port-forward \


### PR DESCRIPTION
- Now that vault-secrets-operator is parametrized for each environment the install.sh script needs to set the --values option.