### PR TITLE
[DM-27867] Revert "Revert cert-manager version"

### DIFF
--- a/services/cert-manager/requirements.yaml
+++ b/services/cert-manager/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: cert-manager
-  version: v0.15.2
+  version: v1.1.0
   repository: https://charts.jetstack.io


### PR DESCRIPTION
This reverts commit 5129919c583121a79661872a7db4def3d9433ccb.
The problem appears to have been due to a glue record, so retry
the upgrade and see if things work properly now.