### PR TITLE
Ensure Argo CD chart versions are consistent

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -15,14 +15,18 @@ echo "Add the argocd helm update..."
 helm repo add argo https://argoproj.github.io/argo-helm
 helm repo update
 
-echo "Update / install argocd using helm..."
+ARGOCD_CHART_VERSION=`grep version \
+  ../services/argocd/requirements.yaml \
+  | tr -d "version: "`
+
+echo "Update / install argocd $ARGOCD_CHART_VERSION using helm..."
 helm upgrade \
   --install argocd argo/argo-cd \
   --values argo-cd-values.yaml \
   --set server.ingress.hosts="{$HOSTNAME}" \
   --namespace argocd \
   --wait --timeout 900 \
-  --version 2.9.5
+  --version $ARGOCD_CHART_VERSION
 
 echo "Creating vault secret..."
 kubectl create secret generic vault-secrets-operator \


### PR DESCRIPTION
- The installer bootstraps Argo CD by installing its Helm chart and then creates the Argo CD app to manage it.
- The version of Argo CD bootstrapped by the installer must be the same as the version synchronized later, otherwise during the synchronization step the argocd-server pod will restart breaking the communication with Argo CD CLI and making the admin password invalid.