### PR TITLE
[DM-28043] Fix up minikube networking

### DIFF
--- a/installer/minikube/coredns.yaml
+++ b/installer/minikube/coredns.yaml
@@ -10,7 +10,6 @@ data:
         health {
            lameduck 5s
         }
-        rewrite name minikube.lsst.codes nginx-ingress-controller.nginx-ingress.svc.cluster.local
         ready
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure

--- a/services/gafaelfawr/values-minikube.yaml
+++ b/services/gafaelfawr/values-minikube.yaml
@@ -11,7 +11,7 @@ gafaelfawr:
   # Use CILogon authentication.
   cilogon:
     client_id: "cilogon:/client_id/74e865cd71a3a327096d36081166b739"
-    redirect_url: "https://minikube.lsst.codes:31337/login"
+    redirect_url: "https://minikube.lsst.codes/login"
     login_params:
       skin: "LSST"
 

--- a/services/mobu/values-minikube.yaml
+++ b/services/mobu/values-minikube.yaml
@@ -1,7 +1,7 @@
 mobu:
   gafaelfawr_secrets_path: "secret/k8s_operator/minikube.lsst.codes/gafaelfawr"
   mobu_secrets_path: "secret/k8s_operator/minikube.lsst.codes/mobu"
-  environment_url: "https://minikube.lsst.codes:31337"
+  environment_url: "https://minikube.lsst.codes"
   host: "minikube.lsst.codes"
 
   image:

--- a/services/nginx-ingress/values-minikube.yaml
+++ b/services/nginx-ingress/values-minikube.yaml
@@ -8,10 +8,11 @@ ingress-nginx:
       ssl-redirect: "true"
       use-forwarded-headers: "true"
     service:
-      externalTrafficPolicy: Local
-      type: NodePort
-      nodePorts:
-        https: 31337
+      type: ClusterIP
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    admissionWebhooks:
+      enabled: false
 
 pull-secret:
   enabled: true

--- a/services/nublado/values-minikube.yaml
+++ b/services/nublado/values-minikube.yaml
@@ -11,7 +11,7 @@ nublado:
       annotations:
         nginx.ingress.kubernetes.io/auth-method: GET
         nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
-        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
+        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
         nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
         nginx.ingress.kubernetes.io/configuration-snippet: |
           proxy_set_header X-Forwarded-Proto https;
@@ -52,7 +52,7 @@ nublado:
       annotations:
         nginx.ingress.kubernetes.io/auth-request-redirect: $request_uri
         nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
-        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
+        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
         nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
         nginx.ingress.kubernetes.io/configuration-snippet: |
           proxy_set_header X-Forwarded-Proto https;

--- a/services/nublado2/values-minikube.yaml
+++ b/services/nublado2/values-minikube.yaml
@@ -15,7 +15,7 @@ nublado2:
     ingress:
       hosts: ["minikube.lsst.codes"]
       annotations:
-        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
-        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr:8080/auth?scope=exec:notebook"
+        nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
+        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
 
   vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"

--- a/services/portal/values-minikube.yaml
+++ b/services/portal/values-minikube.yaml
@@ -7,7 +7,7 @@ firefly:
     annotations:
       nginx.ingress.kubernetes.io/auth-method: GET
       nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Uid, X-Auth-Request-Token
-      nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
+      nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
       nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:portal"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Original-URI $request_uri;


### PR DESCRIPTION
Okay, so first off, this came about by not being able to get to the
gafaelfawr token endpoint, due to the annotations being wrong (no
port), and no way to configure it.

Realizing I'm digging a hole rather than making a pile, I found a
way to configure the nginx-ingress to use the host networking on
80 and 443 (which is actually the VM's host).  This means we can
get rid of port 31337 (picked because NodePorts can only have
ephemeral range).

Using the host network also allows the pod to contact itself,
something it couldn't do previously since it wasn't attached to
the host networking stack.

One downside is that I haven't gotten the admissions webhook
service working yet, and this means that you won't get a warning
if you make an editing goof in your ingress yaml.  But only for
minikube.  I think this can be fixed later, but I'm not sure how,
it has to do with binding that to a nodeport or something.

We will also need to notify CILogon to change the redirect URL
to not redirect to 31337 but instead just 443.