### PR TITLE
DM-28135: exposurelog: add site_id and disable nts deployment

### DIFF
--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -9,7 +9,7 @@ cert_manager:
 chronograf:
   enabled: false
 exposurelog:
-  enabled: true
+  enabled: false
 gafaelfawr:
   enabled: true
 influxdb:

--- a/science-platform/values-nts.yaml
+++ b/science-platform/values-nts.yaml
@@ -9,7 +9,7 @@ cert_manager:
 chronograf:
   enabled: false
 exposurelog:
-  enabled: false
+  enabled: true
 gafaelfawr:
   enabled: true
 influxdb:

--- a/services/exposurelog/values-bleed.yaml
+++ b/services/exposurelog/values-bleed.yaml
@@ -1,5 +1,7 @@
 exposurelog:
-  pull_secret: 'pull-secret'
+  pull_secret: pull-secret
+
+  site_id: bleed
   # Use the built-in toy registry, so set neither butler_uri_1 nor butler_uri_2
 
   ingress:

--- a/services/exposurelog/values-nts.yaml
+++ b/services/exposurelog/values-nts.yaml
@@ -2,11 +2,9 @@ exposurelog:
   pull_secret: pull-secret
 
   site_id: nts
-  # The following is not the correct registry,
-  # so I have disabled the nts deployment for now.
-  nfs_path_1: /offline/teststand  # Mounted as /volume_1
+  nfs_path_1: /data/lsstdata  # Mounted as /volume_1
   nfs_server_1: lsst-nfs.ncsa.illinois.edu
-  butler_uri_1: /volume_1/NCSA_comcam/gen3repo
+  butler_uri_1: /volume_1/NTS/comcam/oods/gen3-butler/repo
 
   ingress:
     enabled: true

--- a/services/exposurelog/values-nts.yaml
+++ b/services/exposurelog/values-nts.yaml
@@ -1,10 +1,11 @@
 exposurelog:
-  pull_secret: 'pull-secret'
+  pull_secret: pull-secret
 
-  nfs_path_1: /offline/teststand
-
+  site_id: nts
+  # The following is not the correct registry,
+  # so I have disabled the nts deployment for now.
+  nfs_path_1: /offline/teststand  # Mounted as /volume_1
   nfs_server_1: lsst-nfs.ncsa.illinois.edu
-
   butler_uri_1: /volume_1/NCSA_comcam/gen3repo
 
   ingress:

--- a/services/exposurelog/values-summit.yaml
+++ b/services/exposurelog/values-summit.yaml
@@ -1,5 +1,7 @@
 exposurelog:
-  pull_secret: 'pull-secret'
+  pull_secret: pull-secret
+
+  site_id: summit
   nfs_path_1: /lsstdata/base/comcam  # Mounted as /volume_1
   nfs_server_1: comcam-arctl01.cp.lsst.org
   butler_uri_1: /volume_1/oods/gen3butler/repo


### PR DESCRIPTION
Add site_id to all existing exposurelog values (bleed, nts, and summit).
Disable deployment at nts because it doesn't have a suitable butler registry.