### PR TITLE
[DM-28198] Portal: use new way to specify hostpath

### DIFF
--- a/services/portal/values-int.yaml
+++ b/services/portal/values-int.yaml
@@ -49,16 +49,8 @@ firefly:
     runAsGroup: 102
 
   volumes:
-    firefly_workarea:
-      emptyDir: null
-      hostPath:
-        path: /sui/firefly/workarea
-        type: Directory
-    firefly_config:
-      emptyDir: null
-      hostPath:
-        path: /sui/firefly/config
-        type: Directory
+    firefly_workarea_hostpath: /sui/firefly/workarea
+    firefly_config_hostpath: /sui/firefly/config
 
 pull-secret:
   enabled: true

--- a/services/portal/values-stable.yaml
+++ b/services/portal/values-stable.yaml
@@ -49,16 +49,8 @@ firefly:
     runAsGroup: 102
 
   volumes:
-    firefly_workarea:
-      emptyDir: null
-      hostPath:
-        path: /sui/firefly/workarea
-        type: Directory
-    firefly_config:
-      emptyDir: null
-      hostPath:
-        path: /sui/firefly/config
-        type: Directory
+    firefly_workarea_hostpath: /sui/firefly/workarea
+    firefly_config_hostpath: /sui/firefly/config
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
This is a slightly different way to configure it based on the
helm chart changes on the same ticket.