### PR TITLE
[DM-27979] Pin ingress IP for idfdev

### DIFF
--- a/services/ingress-nginx/values-idfdev.yaml
+++ b/services/ingress-nginx/values-idfdev.yaml
@@ -9,6 +9,7 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+      loadBalancerIP: "35.225.112.77"
 
 pull-secret:
   enabled: true


### PR DESCRIPTION
Pin the ingress IP to the static IP created via Terraform for the
IDF development environment.