### PR TITLE
[DM-28256] Vault TLS certificate loading

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -175,6 +175,27 @@ def generate_pull_secret():
         return {".dockerconfigjson": f.read()}
 
 
+def generate_ingress_nginx_secrets():
+    key_file = input_field(
+        "ingress-nginx",
+        "cert.key",
+        "Certificate private key filename",
+    )
+
+    cert_file = input_field(
+        "ingress-nginx",
+        "cert.pem",
+        "Certificate public key filename",
+    )
+
+    with open(key_file, "r") as k, \
+         open(cert_file, "r") as c:
+        return {
+            "tls.crt": c.read(),
+            "tls.key": k.read()
+        }
+
+
 def generate_secrets():
     secrets = {}
     secrets["pull-secret"] = generate_pull_secret()
@@ -187,7 +208,13 @@ def generate_secrets():
     secrets["nublado2"] = generate_nublado2_secrets()
     secrets["mobu"] = generate_mobu_secrets()
     secrets["gafaelfawr"] = generate_gafaelfawr_secrets()
-    secrets["cert-manager"] = generate_cert_manager_secrets()
+
+    use_cert_file = input("Use certificate file? (y/n): ")
+
+    if use_cert_file == "y":
+        secrets["ingress-nginx"] = generate_ingress_nginx_secrets()
+    else:
+        secrets["cert-manager"] = generate_cert_manager_secrets()
 
     return secrets
 

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -5,9 +5,9 @@ argo:
 cachemachine:
   enabled: true
 cert_issuer:
-  enabled: true
+  enabled: false
 cert_manager:
-  enabled: true
+  enabled: false
 chronograf:
   enabled: false
 exposurelog:

--- a/services/ingress-nginx/templates/vault-certificate.yaml
+++ b/services/ingress-nginx/templates/vault-certificate.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.vault_certificate.enabled }}
+apiVersion: ricoberger.de/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ingress-certificate
+spec:
+  path: {{ .Values.vault_certificate.path }}
+  type: kubernetes.io/tls
+{{ end }}

--- a/services/ingress-nginx/values-bleed.yaml
+++ b/services/ingress-nginx/values-bleed.yaml
@@ -12,6 +12,9 @@ ingress-nginx:
     podLabels:
       hub.jupyter.org/network-access-proxy-http: "true"
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/bleed.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-gold-leader.yaml
+++ b/services/ingress-nginx/values-gold-leader.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/gold-leader.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-idfdev.yaml
+++ b/services/ingress-nginx/values-idfdev.yaml
@@ -11,6 +11,9 @@ ingress-nginx:
       externalTrafficPolicy: Local
       loadBalancerIP: "35.225.112.77"
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/data-dev.lsst.cloud/pull-secret

--- a/services/ingress-nginx/values-idfint.yaml
+++ b/services/ingress-nginx/values-idfint.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/data-int.lsst.cloud/pull-secret

--- a/services/ingress-nginx/values-minikube.yaml
+++ b/services/ingress-nginx/values-minikube.yaml
@@ -13,6 +13,12 @@ ingress-nginx:
     dnsPolicy: ClusterFirstWithHostNet
     admissionWebhooks:
       enabled: false
+    extraArgs:
+      default-ssl-certificate: ingress-nginx/ingress-certificate
+
+vault_certificate:
+  enabled: true
+  path: secret/k8s_operator/minikube.lsst.codes/ingress-nginx
 
 pull-secret:
   enabled: true

--- a/services/ingress-nginx/values-nublado.yaml
+++ b/services/ingress-nginx/values-nublado.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/nublado.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-red-five.yaml
+++ b/services/ingress-nginx/values-red-five.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/red-five.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-rogue-two.yaml
+++ b/services/ingress-nginx/values-rogue-two.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/rogue-two.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-squash-sandbox.yaml
+++ b/services/ingress-nginx/values-squash-sandbox.yaml
@@ -9,3 +9,6 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+
+vault_certificate:
+  enabled: false

--- a/services/ingress-nginx/values-tucson-teststand.yaml
+++ b/services/ingress-nginx/values-tucson-teststand.yaml
@@ -10,6 +10,9 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
 
+vault_certificate:
+  enabled: false
+
 pull-secret:
   enabled: true
   path: secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret


### PR DESCRIPTION
Load the certificate from a vault secret.

Disable for all environments other than minikube for now, although
forks of this repo may use this feature.  This means that instead
of using let's encrypt, minikube will use the certificate stored
in vault, not stressing our rate limits.