### PR TITLE
[DM-27982] Install rancher-external-ip-webhook in bleed

### DIFF
--- a/science-platform/templates/rancher-external-ip-webhook-application.yaml
+++ b/science-platform/templates/rancher-external-ip-webhook-application.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rancher_external_ip_webhook.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rancher-external-ip-webhook
+spec:
+  finalizers:
+    - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rancher-external-ip-webhook
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: rancher-external-ip-webhook
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: services/rancher-external-ip-webhook
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.revision }}
+    helm:
+      valueFiles:
+        - values-{{ .Values.environment }}.yaml
+{{- end -}}

--- a/science-platform/values-bleed.yaml
+++ b/science-platform/values-bleed.yaml
@@ -16,6 +16,8 @@ gafaelfawr:
   enabled: true
 influxdb:
   enabled: false
+ingress_nginx:
+  enabled: true
 kapacitor:
   enabled: false
 landing_page:
@@ -23,8 +25,6 @@ landing_page:
 logging:
   enabled: false
 mobu:
-  enabled: true
-ingress_nginx:
   enabled: true
 nublado:
   enabled: true
@@ -35,6 +35,8 @@ obstap:
 portal:
   enabled: true
 postgres:
+  enabled: true
+rancher_external_ip_webhook:
   enabled: true
 squash_api:
   enabled: false

--- a/science-platform/values-minikube.yaml
+++ b/science-platform/values-minikube.yaml
@@ -7,7 +7,7 @@ cachemachine:
 cert_issuer:
   enabled: false
 cert_manager:
-  enabled: false
+  enabled: true
 chronograf:
   enabled: false
 exposurelog:
@@ -35,6 +35,8 @@ obstap:
 portal:
   enabled: true
 postgres:
+  enabled: true
+rancher_external_ip_webhook:
   enabled: true
 squash_api:
   enabled: false

--- a/science-platform/values.yaml
+++ b/science-platform/values.yaml
@@ -14,6 +14,8 @@ gafaelfawr:
   enabled: false
 influxdb:
   enabled: false
+ingress_nginx:
+  enabled: false
 kapacitor:
   enabled: false
 landing_page:
@@ -21,8 +23,6 @@ landing_page:
 logging:
   enabled: false
 mobu:
-  enabled: false
-ingress_nginx:
   enabled: false
 nublado:
   enabled: false
@@ -33,6 +33,8 @@ obstap:
 portal:
   enabled: false
 postgres:
+  enabled: false
+rancher_external_ip_webhook:
   enabled: false
 squash_api:
   enabled: false

--- a/services/argocd/values-bleed.yaml
+++ b/services/argocd/values-bleed.yaml
@@ -27,6 +27,8 @@ argo-cd:
           name: ingress-nginx
         - url: https://charts.helm.sh/stable
           name: stable
+        - url: https://charts.rancher.io
+          name: rancher
 
 pull-secret:
   enabled: true

--- a/services/rancher-external-ip-webhook/Chart.yaml
+++ b/services/rancher-external-ip-webhook/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rancher-external-ip-webhook
+version: 1.0.0
+dependencies:
+  - name: rancher-external-ip-webhook
+    version: 0.1.600
+    repository: https://charts.rancher.io/
+  - name: pull-secret
+    version: ">=0.1.2"
+    repository: https://lsst-sqre.github.io/charts/

--- a/services/rancher-external-ip-webhook/values-bleed.yaml
+++ b/services/rancher-external-ip-webhook/values-bleed.yaml
@@ -1,0 +1,11 @@
+rancher-external-ip-webhook:
+  certificates:
+    certManager:
+      version: 1.0.0
+  image:
+    pullSecrets:
+      - pull-secret
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/bleed.lsst.codes/pull-secret

--- a/services/rancher-external-ip-webhook/values-minikube.yaml
+++ b/services/rancher-external-ip-webhook/values-minikube.yaml
@@ -1,0 +1,8 @@
+rancher-external-ip-webhook:
+  image:
+    pullSecrets:
+      - pull-secret
+
+pull-secret:
+  enabled: true
+  path: secret/k8s_operator/bleed.lsst.codes/pull-secret


### PR DESCRIPTION
This admission controller is required to mitigate CVE-2020-8554.
This is a vulnerability in Kubernetes that allows anyone who can
create a pod to claim an IP address via externalIP configuration,
at which point Kubernetes will route all the traffic for that IP
to that pod.  The pod can claim addresses like 8.8.8.8 and run a
rogue DNS server or do other malicious things.

Since we allow users to create pods in the Science Platform, our
Kubernetes environment is effectively multi-tenant and we need to
prohibit this.

Install only in bleed and minikube for now to confirm that it
works.  cert-manager is required for the webhook, so install it
again on minikube (but not the cert issuer that uses Route 53).