### PR TITLE
[DM-27983] Flesh out cert-issuer documentation

### DIFF
--- a/docs/cert-issuer/bootstrapping.rst
+++ b/docs/cert-issuer/bootstrapping.rst
@@ -1,0 +1,55 @@
+#########################
+Bootstrapping cert-issuer
+#########################
+
+The issuer defined in the ``cert-issuer`` application uses the DNS solver.
+The advantage of the DNS solver is that it works behind firewalls and can provision certificates for environments not exposed to the Internet, such as the Tucson teststand.
+The DNS solver uses an AWS service user with write access to Route 53 to answer Let's Encrypt challenges.
+
+First, ensure that ``cert-issuer`` is set up for the domain in which the cluster will be hosted.
+If this is a new domain, follow the instructions in :doc:`route53-setup`.
+
+Then, in Route 53, create a CNAME from ``_acme-challenge.<cluster-name>`` to ``_acme-challenge.tls.<domain>`` where ``<domain>`` is the domain in which the cluster is located (such as ``lsst.codes`` or ``lsst.cloud``).
+The new Route 53 dialog box makes this very confusing to do in the console.
+Select **CNAME** from the lower drop-down menu and then **IP address or other value** from the top drop-down menu, and then you can enter ``_acme-challenge.tls.lsst.codes`` (for example) as the CNAME target.
+
+For example, if the cluster name is ``data-dev.lsst.cloud``, create a CNAME record at ``_acme-challenge.data-dev.lsst.cloud`` whose value is ``_acme-challenge.tls.lsst.cloud``.
+In the Route 53 console, the name of the record you create in the ``lsst.cloud`` hosted zone will be ``_acme-challenge.data-dev`` (yes, including the period).
+
+Add the following to the ``values-*.yaml`` file for an environment:
+
+.. code-block:: yaml
+
+   solver:
+     route53:
+       aws-access-key-id: <access-key>
+       hosted-zone: <hosted-zone>
+       vault-secret-path: "secret/k8s_operator/<cluster-name>/cert-manager"
+
+replacing ``<cluster-name>`` with the FQDN of the cluster, corresponding to the root of the Vault secrets for that cluster (see :doc:`../vault-secrets-operator/index`).
+
+``<access-key>`` and ``<hosted-zone>`` must correspond to the domain under which the cluster is hosted.
+The values for the two most common Rubin Science Platform domains are:
+
+.. code-block:: yaml
+
+   lsst.codes:
+     aws-access-key-id: AKIAQSJOS2SFLUEVXZDB
+     hosted-zone: Z06873202D7WVTZUFOQ42
+   lsst.cloud:
+     aws-access-key-id: AKIAQSJOS2SFKQBMDRGR
+     hosted-zone: Z0567328105IEHEMIXLCO
+
+This key ID is for an AWS service user that has write access to the ``tls`` subdomain of the domain in which the cluster is hosted, and therefore can answer challenges.
+
+Finally, store the secret key for this AWS access key in Vault as the ``cert-manager`` secret for that cluster.
+The Vault secret should look something like this:
+
+.. code-block:: yaml
+
+   data:
+     aws-access-key-id: <access-key>
+     aws-secret-access-key: <secret>
+
+The secrets for the SQuaRE-maintained Rubin Science Platform domains are stored in 1Password (search for ``cert-manager-lsst-codes`` or ``cert-manager-lsst-cloud``).
+If this cluster is in the same domain as another, working cluster, you can copy the secret from that cluster into the appropriate path for the new cluster.

--- a/docs/cert-issuer/index.rst
+++ b/docs/cert-issuer/index.rst
@@ -15,52 +15,28 @@ cert-issuer
 .. rubric:: Overview
 
 The ``cert-issuer`` application creates a cluster issuer for the use of the Rubin Science Platform.
+It depends on `cert-manager <https://cert-manager.io>`__.
 The issuer is named ``cert-issuer-letsencrypt-dns``.
+
+On most clusters where the Rubin Science Platform manages certificates, this is also handled by the Rubin Science Platform Argo CD, but on the base and summit clusters, cert-manager is maintained by IT and installed outside of Argo CD.
+NCSA clusters use NCSA certificates issued via an internal process.
+
+.. rubric:: Using cert-issuer
+
 To configure an ingress to use certificates issued by it, add a ``tls`` configuration to the ingress and the annotation:
 
 .. code-block:: yaml
 
    cert-manager.io/cluster-issuer: cert-issuer-letsencrypt-dns
 
-It depends on `cert-manager <https://cert-manager.io>`__.
-On most clusters where the Rubin Science Platform manages certificates, this is also handled by the Rubin Science Platform Argo CD, but on the base and summit clusters, cert-manager is maintained by IT and installed outside of Argo CD.
+.. rubric:: Guides
 
-.. rubric:: Bootstrapping the application
+.. toctree::
 
-The issuer defined in the ``cert-issuer`` application uses the DNS solver.
-The advantage of the DNS solver is that it works behind firewalls and can provision certificates for environments not exposed to the Internet, such as the Tucson teststand.
+   route53-setup
+   bootstrapping
 
-The DNS solver uses an AWS service user with write access to Route 53 to answer Let's Encrypt challenges.
-To configure it, add the following to the ``values-*.yaml`` file for an environment:
+.. seealso::
 
-.. code-block:: yaml
-
-   solver:
-     route53:
-       aws-access-key-id: AKIAQSJOS2SFLUEVXZDB
-       hosted-zone: Z06873202D7WVTZUFOQ42
-       vault-secret-path: "secret/k8s_operator/<cluster-name>/cert-manager"
-
-replacing ``<cluster-name>`` with the FQDN of the cluster, corresponding to the root of the Vault secrets for that cluster.
-See :doc:`../vault-secrets-operator/index` for more information.
-
-Then, in Route 53, create a CNAME from ``_acme-challenge.<cluster-name>`` to ``_acme-challenge.tls.lsst.codes``.
-The new Route 53 dialog box makes this very confusing to do in the console.
-Select **CNAME** from the lower drop-down menu and then **IP address or other value** from the top drop-down menu, and then you can enter ``_acme-challenge.tls.lsst.codes`` as the CNAME target.
-
-The access key ID in the configuration corresponds to the ``cert-manager-lsst-codes`` service user in AWS.
-The hosted zone is the ``tls.lsst.codes`` hosted zone, where all challenge responses will be created.
-To limit the scope of access in case of a compromise, this AWS service user does not have write access to the full ``lsst.codes`` domain (hence the need for the CNAME).
-This AWS service user can be used for all Science Platform deployments in the ``lsst.codes`` domain.
-It is configured according to the `cert-manager documentation for Route 53 <https://cert-manager.io/docs/configuration/acme/dns01/route53/>`__.
-
-The secret key for this AWS access key must be stored in Vault as the ``cert-manager`` secret for that cluster.
-The Vault secret should look something like this:
-
-.. code-block:: yaml
-
-   data:
-     aws-access-key-id: AKIAQSJOS2SFLUEVXZDB
-     aws-secret-access-key: <secret>
-
-The secret is stored in 1Password (search for ``cert-manager-lsst-codes``).
+   * :doc:`../cert-manager/index`
+   * `cert-manager documentation for Route 53 <https://cert-manager.io/docs/configuration/acme/dns01/route53/>`__.

--- a/docs/cert-issuer/route53-setup.rst
+++ b/docs/cert-issuer/route53-setup.rst
@@ -1,0 +1,57 @@
+###################################
+Setting up Route 53 for cert-issuer
+###################################
+
+Each domain under which ``cert-issuer`` needs to issue certificates must be configured in AWS.
+This involves creating a new hosted zone for the DNS challenges for that domain, creating an AWS service user with an appropriate IAM policy, and creating an access key for that user which will be used by ``cert-manager``.
+
+Normally, DNS challenges work by writing a text record to the ``_acme-challenge.<hostname>`` record for the hostname for which one is obtaining a certificate.
+However, Route 53 IAM policies are only granular to the level of a hosted zone.
+To give ``cert-manager`` write access to the whole hosted zone would be exessive, since it could then modify any other records.
+Therefore, we use a strategy documented in the `cert-manager documentation for Route 53 <https://cert-manager.io/docs/configuration/acme/dns01/route53/>`__ to delegate only the relevant records.
+
+To do this for a new zone, do the following.
+In these instructions, the new zone is shown as ``new.zone``.
+In practice this will be a zone like ``lsst.codes`` or ``lsst.cloud``.
+
+#. Create a new hosted zone named ``tls.new.zone`` in Route 53.
+   Make a note of its zone ID.
+
+#. Add the NS glue record for ``tls.new.zone`` to ``new.zone`` in Route 53.
+
+#. Create a new IAM user named ``cert-manager-new-zone``.
+   Attach an inline IAM policy for that user that gives it access to the new ``tls.new.zone`` hosted zone.
+
+   .. code-block:: json
+
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Sid": "VisualEditor0",
+                  "Effect": "Allow",
+                  "Action": "route53:GetChange",
+                  "Resource": "arn:aws:route53:::change/*"
+              },
+              {
+                  "Sid": "VisualEditor1",
+                  "Effect": "Allow",
+                  "Action": [
+                      "route53:ChangeResourceRecordSets",
+                      "route53:ListResourceRecordSets"
+                  ],
+                  "Resource": "arn:aws:route53:::hostedzone/<zone-id>"
+              }
+          ]
+      }
+
+   replacing ``<zone-id>`` with the ID of the hosted zone.
+   (This will be a string similar to ``Z0567328105IEHEMIXLCO``.)
+
+#. Create an access key for that user.
+   Store the access key and secret key pair in 1Password as ``cert-manager-new-zone``.
+
+You can now follow the instructions in :doc:`bootstrapping` to set up the new cluster.
+
+The above instructions only have to be done once per domain.
+After that, any new clusters in the same domain will only need the addition of a CNAME and some Vault and Argo CD configuration, as described in :doc:`bootstrapping`.

--- a/docs/cert-manager/index.rst
+++ b/docs/cert-manager/index.rst
@@ -17,6 +17,8 @@ cert-manager
 The ``cert-manager`` application is an installation of `cert-manager <https://cert-manager.io>`__ from its `Helm chart repository <https://hub.helm.sh/charts/jetstack/cert-manager>`__.
 It creates TLS certificates via `Let's Encrypt <https://letsencrypt.org/>`__ and automatically renews them.
 
+See the :doc:`cert-issuer application <../cert-issuer/index>` for how ``cert-manager`` is used.
+
 This application is only deployed on clusters managed by SQuaRE.
 NCSA clusters use NCSA certificates issued via an internal process.
 IT manages the cert-manager installation on the base and summit Rubin Science Platform clusters.


### PR DESCRIPTION
Add documentation for setting up Route 53 for a new zone, and be
clearer about the steps for setting up cert-issuer for a new cluster.
Reference the cert-issuer documentation from cert-manager.