### PR TITLE
[DM-28463] Enable cert-manager and ingress-nginx at base and summit

### DIFF
--- a/science-platform/values-base.yaml
+++ b/science-platform/values-base.yaml
@@ -5,7 +5,7 @@ argo:
 cert_issuer:
   enabled: true
 cert_manager:
-  enabled: false
+  enabled: true
 chronograf:
   enabled: false
 exposurelog:
@@ -23,7 +23,7 @@ logging:
 mobu:
   enabled: false
 ingress_nginx:
-  enabled: false
+  enabled: true
 nublado:
   enabled: true
 obstap:

--- a/science-platform/values-summit.yaml
+++ b/science-platform/values-summit.yaml
@@ -5,7 +5,7 @@ argo:
 cert_issuer:
   enabled: true
 cert_manager:
-  enabled: false
+  enabled: true
 chronograf:
   enabled: false
 exposurelog:

--- a/services/ingress-nginx/values-base.yaml
+++ b/services/ingress-nginx/values-base.yaml
@@ -9,11 +9,13 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
-      loadBalancerIP: "140.252.34.101"
+      loadBalancerIP: "139.229.146.150"
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false
 
 pull-secret:
   enabled: true
-  path: secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret
+  path: secret/k8s_operator/base-lsp.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-gold-leader.yaml
+++ b/services/ingress-nginx/values-gold-leader.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-idfdev.yaml
+++ b/services/ingress-nginx/values-idfdev.yaml
@@ -10,6 +10,8 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
       loadBalancerIP: "35.225.112.77"
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-idfint.yaml
+++ b/services/ingress-nginx/values-idfint.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-minikube.yaml
+++ b/services/ingress-nginx/values-minikube.yaml
@@ -15,6 +15,8 @@ ingress-nginx:
       enabled: false
     extraArgs:
       default-ssl-certificate: ingress-nginx/ingress-certificate
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: true

--- a/services/ingress-nginx/values-nublado.yaml
+++ b/services/ingress-nginx/values-nublado.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-red-five.yaml
+++ b/services/ingress-nginx/values-red-five.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-rogue-two.yaml
+++ b/services/ingress-nginx/values-rogue-two.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-squash-sandbox.yaml
+++ b/services/ingress-nginx/values-squash-sandbox.yaml
@@ -9,6 +9,8 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false

--- a/services/ingress-nginx/values-summit.yaml
+++ b/services/ingress-nginx/values-summit.yaml
@@ -9,11 +9,13 @@ ingress-nginx:
       use-forwarded-headers: "true"
     service:
       externalTrafficPolicy: Local
-      loadBalancerIP: "140.252.34.101"
+      loadBalancerIP: "139.229.160.150"
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false
 
 pull-secret:
   enabled: true
-  path: secret/k8s_operator/tucson-teststand.lsst.codes/pull-secret
+  path: secret/k8s_operator/summit-lsp.lsst.codes/pull-secret

--- a/services/ingress-nginx/values-tucson-teststand.yaml
+++ b/services/ingress-nginx/values-tucson-teststand.yaml
@@ -10,6 +10,8 @@ ingress-nginx:
     service:
       externalTrafficPolicy: Local
       loadBalancerIP: "140.252.34.101"
+    podLabels:
+      hub.jupyter.org/network-access-proxy-http: "true"
 
 vault_certificate:
   enabled: false


### PR DESCRIPTION
For now, we'll be managing cert-manager and ingress-nginx in the
antu and andes clusters.  Enable them and add the required values
files for ingress-nginx.

Try to pin the IP addresses for base, summit, and tucson-teststand
since we hopefully should be able to request the same IP address as
we're currently using in those clusters.