### PR TITLE
[DM-28472] Add exposurelog_password to generate_secrets

### DIFF
--- a/installer/generate_secrets.py
+++ b/installer/generate_secrets.py
@@ -85,6 +85,7 @@ def generate_log_secrets():
 
 def generate_postgres_secrets():
     return {
+        "exposurelog_password": secrets.token_hex(32),
         "jupyterhub_password": secrets.token_hex(32),
         "root_password": secrets.token_hex(64),
     }


### PR DESCRIPTION
This apparently got left out, but is needed if that secret is
pulled from postgres.