### PR TITLE
[DM-28454] Delete requirements.yaml

### DIFF
--- a/services/tap/requirements.yaml
+++ b/services/tap/requirements.yaml
@@ -1,7 +1,0 @@
-dependencies:
-- name: cadc-tap
-  version: ">=0.1.0"
-  repository: https://lsst-sqre.github.io/charts/
-- name: pull-secret
-  version: 0.1.2
-  repository: https://lsst-sqre.github.io/charts/


### PR DESCRIPTION
This should be wrapped up in the Chart.yaml now for helm 3.

Maybe the existance of this file is causing some kind of strange
error I'm seeing?