### PR TITLE
[DM-28666] Update Nublado 2 configuration

### DIFF
--- a/services/nublado2/values-bleed.yaml
+++ b/services/nublado2/values-bleed.yaml
@@ -16,6 +16,8 @@ nublado2:
       hosts: ["bleed.lsst.codes"]
       annotations:
         nginx.ingress.kubernetes.io/auth-signin: "https://bleed.lsst.codes/login"
-        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr:8080/auth?scope=exec:notebook"
+
+  config:
+    base_url: "https://bleed.lsst.codes/"
 
   vault_secret_path: "secret/k8s_operator/bleed.lsst.codes/nublado2"

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -16,6 +16,8 @@ nublado2:
       hosts: ["data-dev.lsst.cloud"]
       annotations:
         nginx.ingress.kubernetes.io/auth-signin: "https://data-dev.lsst.cloud/login"
-        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
+
+  config:
+    base_url: "https://data-dev.lsst.cloud/"
 
   vault_secret_path: "secret/k8s_operator/data-dev.lsst.cloud/nublado2"

--- a/services/nublado2/values-minikube.yaml
+++ b/services/nublado2/values-minikube.yaml
@@ -16,6 +16,8 @@ nublado2:
       hosts: ["minikube.lsst.codes"]
       annotations:
         nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes/login"
-        nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
+
+  config:
+    base_url: "https://minikube.lsst.codes/"
 
   vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"


### PR DESCRIPTION
Add the base_url parameter required by the new version of the chart
and remove the now-unnecessary auth-url setting.