### PR TITLE
[DM-28482] Try to run as provisionator

### DIFF
--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -11,6 +11,7 @@ nublado2:
         tag: "master"
 
     singleuser:
+      uid: 769
       storage:
         type: none
         extraVolumes:
@@ -69,7 +70,6 @@ nublado2:
           SODA_ROUTE: /api/image/soda
           WORKFLOW_ROUTE: /wf
           AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
-          NO_SUDO: "true"
           EXTERNAL_GROUPS: "{{groups}}"
           EXTERNAL_UID: "{{uid}}"
           ACCESS_TOKEN: "{{token}}"

--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -53,12 +53,12 @@ nublado2:
       - apiVersion: v1
         kind: Namespace
         metadata:
-          name: "n2-{{user}}"
+          name: "nublado2-{{user}}"
       - apiVersion: v1
         kind: ConfigMap
         metadata:
           name: lab-environment
-          namespace: "n2-{{user}}"
+          namespace: "nublado2-{{user}}"
         data:
           EXTERNAL_INSTANCE_URL: "{{base_url}}"
           FIREFLY_ROUTE: /portal/app


### PR DESCRIPTION
Maybe this will work?

Also, since the namespace is nublado2 on the datadev, we need to make these user created resources in the right namespace that nublado2 is also writing to.  I should probably factor this out in the near future to automatically put the namespace in, since that will be a major annoyance.