### PR TITLE
[DM-28482] Nublado2: use proper external_groups

### DIFF
--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -70,7 +70,7 @@ nublado2:
           SODA_ROUTE: /api/image/soda
           WORKFLOW_ROUTE: /wf
           AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
-          EXTERNAL_GROUPS: "{{groups}}"
+          EXTERNAL_GROUPS: "{{external_groups}}"
           EXTERNAL_UID: "{{uid}}"
           ACCESS_TOKEN: "{{token}}"
 


### PR DESCRIPTION
The groups here is just a list of groups, but not in the proper
format we need.  That's external_groups