### PR TITLE
[DM-28482] Don't use uid, user_namespace

### DIFF
--- a/services/nublado2/values-idfdev.yaml
+++ b/services/nublado2/values-idfdev.yaml
@@ -11,7 +11,6 @@ nublado2:
         tag: "master"
 
     singleuser:
-      uid: 769
       storage:
         type: none
         extraVolumes:
@@ -54,12 +53,12 @@ nublado2:
       - apiVersion: v1
         kind: Namespace
         metadata:
-          name: "nublado2-{{user}}"
+          name: "{{user_namespace}}"
       - apiVersion: v1
         kind: ConfigMap
         metadata:
           name: lab-environment
-          namespace: "nublado2-{{user}}"
+          namespace: "{{user_namespace}}"
         data:
           EXTERNAL_INSTANCE_URL: "{{base_url}}"
           FIREFLY_ROUTE: /portal/app


### PR DESCRIPTION
Don't use the singleuser uid in the chart, we'll use pod_uid's
default which is in the nublado2 chart now.

Also, we can use the user_namespace template variable now, which
will automatically know and compute the proper namespace for us,
so that means the templating can be more cookie cutter.