### PR TITLE
[DM-28845] Revert "Switch bleed environment to Gafaelfawr branch"

### DIFF
--- a/services/gafaelfawr/values-bleed.yaml
+++ b/services/gafaelfawr/values-bleed.yaml
@@ -3,9 +3,6 @@ gafaelfawr:
   host: bleed.lsst.codes
   ingress:
     host: bleed.lsst.codes
-  image:
-    tag: "tickets-DM-28845"
-    pullPolicy: "Always"
   vault_secrets_path: "secret/k8s_operator/bleed.lsst.codes/gafaelfawr"
 
   # Session length and token expiration (in minutes).


### PR DESCRIPTION
This reverts commit 33a1585027e6eeea4e7aaac045a491e28d32fd1e.
CILogon has been fixed.