### PR TITLE
[DM-28845] Point bleed back to regular CILogon for now

### DIFF
--- a/services/gafaelfawr/values-bleed.yaml
+++ b/services/gafaelfawr/values-bleed.yaml
@@ -17,7 +17,6 @@ gafaelfawr:
   cilogon:
     client_id: "cilogon:/client_id/4fb3456c6d99009d975450af19bee94"
     redirect_url: "https://bleed.lsst.codes/oauth2/callback"
-    test: true
     login_params:
       skin: "LSST"
 


### PR DESCRIPTION
test.cilogon.org still has the broken code that means we don't get
uidNumber, so switch it back to regular CILogon for now.